### PR TITLE
Optimize script execution

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -236,11 +236,13 @@ Scripts can be read from file system or directly from memory.
 public class ScriptingBenchmarks {
     private static final Path path = Paths.get("src/jmh/tweakflow/condition.tf");
 
+    private static final Path watchedDir = Paths.get("src/jmh/tweakflow");
+
     public static String buildScript() {
-        StringBuilder b = new StringBuilder();
+        StringBuilder b = new StringBuilder("");
         b.append("library echopraxia {");
         b.append("  function evaluate: (string level, dict fields) ->");
-        b.append("    fields[:correlation_id] == \"match\";");
+        b.append("    level == \"INFO\";");
         b.append("}");
         return b.toString();
     }
@@ -251,28 +253,48 @@ public class ScriptingBenchmarks {
     private static final Condition stringCondition =
             ScriptCondition.create(false, buildScript(), Throwable::printStackTrace);
 
+    private static final ScriptWatchService scriptWatchService = new ScriptWatchService(watchedDir);
+
+    private static final ScriptHandle watchedScript =
+            scriptWatchService.watchScript(
+                    watchedDir.resolve("condition.tf"), Throwable::printStackTrace);
+
+    private static final Condition watchedCondition = ScriptCondition.create(false, watchedScript);
+
     @Benchmark
     public void testFileConditionMatch(Blackhole blackhole) {
-        // ScriptingBenchmarks.testFileConditionMatch    avgt    5  208.966 ± 15.136  ns/op
+        // ScriptingBenchmarks.testFileConditionMatch     avgt    5  127.251 ± 0.816  ns/op
         blackhole.consume(fileCondition.test(Level.INFO, LogstashLoggingContext.empty()));
     }
 
     @Benchmark
     public void testStringConditionMatch(Blackhole blackhole) {
-        // ScriptingBenchmarks.testFileConditionMatch    avgt    5  208.966 ± 15.136  ns/op
+        // ScriptingBenchmarks.testStringConditionMatch   avgt    5  122.905 ± 3.440  ns/op
         blackhole.consume(stringCondition.test(Level.INFO, LogstashLoggingContext.empty()));
     }
 
     @Benchmark
     public void testFileConditionFail(Blackhole blackhole) {
-        // ScriptingBenchmarks.testFileConditionFail     avgt    5  203.641 ±  0.959  ns/op
+        // ScriptingBenchmarks.testFileConditionFail      avgt    5  112.629 ± 2.951  ns/op
         blackhole.consume(fileCondition.test(Level.DEBUG, LogstashLoggingContext.empty()));
     }
 
     @Benchmark
     public void testStringConditionFail(Blackhole blackhole) {
-        // ScriptingBenchmarks.testStringConditionFail   avgt    5  198.490 ±  1.657  ns/op
+        // ScriptingBenchmarks.testStringConditionFail    avgt    5  118.323 ± 4.296  ns/op
         blackhole.consume(stringCondition.test(Level.DEBUG, LogstashLoggingContext.empty()));
+    }
+
+    @Benchmark
+    public void testWatchedConditionMatch(Blackhole blackhole) {
+        // ScriptingBenchmarks.testWatchedConditionMatch  avgt    5  134.601 ± 2.325  ns/op
+        blackhole.consume(watchedCondition.test(Level.INFO, LogstashLoggingContext.empty()));
+    }
+
+    @Benchmark
+    public void testWatchedConditionFail(Blackhole blackhole) {
+        // ScriptingBenchmarks.testWatchedConditionFail   avgt    5  125.652 ± 5.286  ns/op
+        blackhole.consume(watchedCondition.test(Level.DEBUG, LogstashLoggingContext.empty()));
     }
 }
 ```

--- a/scripting/src/jmh/java/com/tersesystems/echopraxia/scripting/ScriptingBenchmarks.java
+++ b/scripting/src/jmh/java/com/tersesystems/echopraxia/scripting/ScriptingBenchmarks.java
@@ -44,37 +44,37 @@ public class ScriptingBenchmarks {
 
   @Benchmark
   public void testFileConditionMatch(Blackhole blackhole) {
-    // ScriptingBenchmarks.testFileConditionMatch    avgt    5  208.966 ± 15.136  ns/op
+    // ScriptingBenchmarks.testFileConditionMatch     avgt    5  127.251 ± 0.816  ns/op
     blackhole.consume(fileCondition.test(Level.INFO, LogstashLoggingContext.empty()));
   }
 
   @Benchmark
   public void testStringConditionMatch(Blackhole blackhole) {
-    // ScriptingBenchmarks.testFileConditionMatch    avgt    5  208.966 ± 15.136  ns/op
+    // ScriptingBenchmarks.testStringConditionMatch   avgt    5  122.905 ± 3.440  ns/op
     blackhole.consume(stringCondition.test(Level.INFO, LogstashLoggingContext.empty()));
   }
 
   @Benchmark
   public void testFileConditionFail(Blackhole blackhole) {
-    // ScriptingBenchmarks.testFileConditionFail     avgt    5  203.641 ±  0.959  ns/op
+    // ScriptingBenchmarks.testFileConditionFail      avgt    5  112.629 ± 2.951  ns/op
     blackhole.consume(fileCondition.test(Level.DEBUG, LogstashLoggingContext.empty()));
   }
 
   @Benchmark
   public void testStringConditionFail(Blackhole blackhole) {
-    // ScriptingBenchmarks.testStringConditionFail   avgt    5  198.490 ±  1.657  ns/op
+    // ScriptingBenchmarks.testStringConditionFail    avgt    5  118.323 ± 4.296  ns/op
     blackhole.consume(stringCondition.test(Level.DEBUG, LogstashLoggingContext.empty()));
   }
 
   @Benchmark
   public void testWatchedConditionMatch(Blackhole blackhole) {
-    // ScriptingBenchmarks.testWatchedConditionFail   avgt    5  236.907 ±  9.992  ns/op
+    // ScriptingBenchmarks.testWatchedConditionMatch  avgt    5  134.601 ± 2.325  ns/op
     blackhole.consume(watchedCondition.test(Level.INFO, LogstashLoggingContext.empty()));
   }
 
   @Benchmark
   public void testWatchedConditionFail(Blackhole blackhole) {
-    // ScriptingBenchmarks.testWatchedConditionMatch  avgt    5  256.803 ± 25.520  ns/op
+    // ScriptingBenchmarks.testWatchedConditionFail   avgt    5  125.652 ± 5.286  ns/op
     blackhole.consume(watchedCondition.test(Level.DEBUG, LogstashLoggingContext.empty()));
   }
 }

--- a/scripting/src/main/java/com/tersesystems/echopraxia/scripting/ScriptWatchService.java
+++ b/scripting/src/main/java/com/tersesystems/echopraxia/scripting/ScriptWatchService.java
@@ -21,8 +21,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 
 /**
- * A service that watches a directory containing scripts, and
- * invalidates a script handle if the file has been touched.
+ * A service that watches a directory containing scripts, and invalidates a script handle if the
+ * file has been touched.
  */
 public class ScriptWatchService implements AutoCloseable {
   private static final Logger<?> logger = LoggerFactory.getLogger();


### PR DESCRIPTION
Cuts tweakflow execution in half by using a thread-local callsite instead of a var.