### PR TITLE
Richer Field Builders

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,13 +142,28 @@ try {
 However, when you log arguments, you pass a function which provides you with a field builder and returns a list of fields:
 
 ```java
+basicLogger.info("Message name {} age {}", fb -> fb.list(
+  fb.string("name", "value"),
+  fb.number("age", 13)
+));
+```
+
+You can specify a single field using `only`:
+
+```java
+basicLogger.info("Message name {}", fb -> fb.only(fb.string("name", "value")));
+```
+
+And there are some shortcut methods like `onlyString` that combine `only` and `string`:
+
+```java
 basicLogger.info("Message name {}", fb -> fb.onlyString("name", "value"));
 ```
 
 You can log multiple arguments and include the exception if you want the stack trace:
 
 ```java
-basicLogger.info("Message name {}", fb -> Arrays.asList(
+basicLogger.info("Message name {}", fb -> fb.list(
   fb.string("name", "value"),
   fb.exception(e)
 ));
@@ -167,7 +182,7 @@ Echopraxia lets you specify custom field builders whenever you want to log domai
     // Renders a date using the `only` idiom returning a list of `Field`.
     // This is a useful shortcut when you only have one field you want to add.
     public List<Field> onlyDate(String name, Date date) {
-      return singletonList(date(name, date));
+      return only(date(name, date));
     }
 
     // Renders a date as an ISO 8601 string.
@@ -207,7 +222,7 @@ This also applies to more complex objects:
 ```java
 Person user = ...
 Logger<PersonFieldBuilder> personLogger = basicLogger.withFieldBuilder(PersonFieldBuilder.class);
-personLogger.info("Person {}", fb -> Arrays.asList(fb.person("user", user)));
+personLogger.info("Person {}", fb -> fb.only(fb.person("user", user)));
 ```
 
 ## Context

--- a/api/src/main/java/com/tersesystems/echopraxia/Field.java
+++ b/api/src/main/java/com/tersesystems/echopraxia/Field.java
@@ -32,18 +32,52 @@ public interface Field {
   Value<?> value();
 
   /**
-   *  The field builder interface.
+   * The field builder interface.
    *
-   *  <p>This is provided in a function for creating fields in context and arguments.
-   *  You are encourage to extend this interface to create your own custom field builders
-   *  to create your own domain specific logic for creating fields.
-   *  </p>
+   * <p>This is provided in a function for creating fields in context and arguments. You are
+   * encourage to extend this interface to create your own custom field builders to create your own
+   * domain specific logic for creating fields.
    */
   interface Builder {
     String EXCEPTION = "exception";
 
     static Builder instance() {
-      return new Field.Builder() {};
+      return KeyValueField.keyValueFieldBuilder;
+    }
+
+    /**
+     * Wraps a single field in a singleton list.
+     *
+     * <p>{@code fb.only(fb.string("correlation_id", "match"))}
+     *
+     * @param field the given field
+     * @return a list containing a single field element.
+     */
+    default List<Field> only(Field field) {
+      return singletonList(field);
+    }
+
+    /**
+     * Wraps fields in a list. More convenient than {@code Arrays.asList}.
+     *
+     * <p>{@code fb.list( fb.string("correlation_id", "match"), fb.number("some_number", 12345) )}
+     *
+     * @param fields the given fields
+     * @return a list containing the fields.
+     */
+    default List<Field> list(Field... fields) {
+      return Arrays.asList(fields);
+    }
+
+    /**
+     * Creates a field.
+     *
+     * @param name the field name
+     * @param value the field value
+     * @return the field.
+     */
+    default Field field(String name, Field.Value<?> value) {
+      return new KeyValueField(name, value);
     }
 
     // string
@@ -56,18 +90,7 @@ public interface Field {
      * @return the field.
      */
     default Field string(String name, String value) {
-      return new DefaultField(name, Value.string(value));
-    }
-
-    /**
-     * Creates a list of fields out of a name and a raw string value.
-     *
-     * @param name the name of the field.
-     * @param value the value of the field.
-     * @return a list containing a single field.
-     */
-    default List<Field> onlyString(String name, String value) {
-      return singletonList(string(name, value));
+      return field(name, Value.string(value));
     }
 
     // number
@@ -80,18 +103,7 @@ public interface Field {
      * @return a list containing a single field.
      */
     default Field number(String name, Number value) {
-      return new DefaultField(name, Value.number(value));
-    }
-
-    /**
-     * Creates a singleton list of fields out of a name and a raw number value.
-     *
-     * @param name the name of the field.
-     * @param value the value of the field.
-     * @return a list containing a single field.
-     */
-    default List<Field> onlyNumber(String name, Number value) {
-      return singletonList(number(name, value));
+      return field(name, Value.number(value));
     }
 
     // boolean
@@ -104,18 +116,7 @@ public interface Field {
      * @return a list containing a single field.
      */
     default Field bool(String name, Boolean value) {
-      return new DefaultField(name, Value.bool(value));
-    }
-
-    /**
-     * Creates a singleton list of fields out of a name and a raw boolean value.
-     *
-     * @param name the name of the field.
-     * @param value the value of the field.
-     * @return a list containing a single field.
-     */
-    default List<Field> onlyBool(String name, Boolean value) {
-      return singletonList(bool(name, value));
+      return field(name, Value.bool(value));
     }
 
     // array
@@ -128,7 +129,7 @@ public interface Field {
      * @return a list containing a single field.
      */
     default Field array(String name, Value<?>... values) {
-      return new DefaultField(name, Value.array(values));
+      return field(name, Value.array(values));
     }
 
     /**
@@ -139,29 +140,7 @@ public interface Field {
      * @return a list containing a single field.
      */
     default Field array(String name, List<Value<?>> values) {
-      return new DefaultField(name, Value.array(values));
-    }
-
-    /**
-     * Creates a singleton list of an array field out of a name and array values.
-     *
-     * @param name the name of the field.
-     * @param values the values.
-     * @return a list containing a single field.
-     */
-    default List<Field> onlyArray(String name, Value<?>... values) {
-      return singletonList(array(name, values));
-    }
-
-    /**
-     * Creates a singleton list of an array field out of a name and a list of values.
-     *
-     * @param name the name of the field.
-     * @param values the values.
-     * @return a list containing a single field.
-     */
-    default List<Field> onlyArray(String name, List<Value<?>> values) {
-      return singletonList(array(name, values));
+      return field(name, Value.array(values));
     }
 
     // object
@@ -173,7 +152,7 @@ public interface Field {
      * @return a single field.
      */
     default Field object(String name, Field... values) {
-      return new DefaultField(name, Value.object(values));
+      return field(name, Value.object(values));
     }
 
     /**
@@ -184,29 +163,7 @@ public interface Field {
      * @return a field.
      */
     default Field object(String name, List<Field> values) {
-      return new DefaultField(name, Value.object(values));
-    }
-
-    /**
-     * Creates a singleton list of an object out of a name and array values.
-     *
-     * @param name the name of the field.
-     * @param values the values.
-     * @return a list containing a single field.
-     */
-    default List<Field> onlyObject(String name, Field... values) {
-      return singletonList(object(name, values));
-    }
-
-    /**
-     * Creates a singleton list of an object out of a name and a list of values.
-     *
-     * @param name the name of the field.
-     * @param values the values.
-     * @return a list containing a single field.
-     */
-    default List<Field> onlyObject(String name, List<Field> values) {
-      return singletonList(object(name, values));
+      return field(name, Value.object(values));
     }
 
     // null
@@ -218,17 +175,7 @@ public interface Field {
      * @return a field.
      */
     default Field nullValue(String name) {
-      return new DefaultField(name, Value.nullValue());
-    }
-
-    /**
-     * Creates a singleton list of a null.
-     *
-     * @param name the name of the field.
-     * @return a list containing a single field.
-     */
-    default List<Field> onlyNullValue(String name) {
-      return singletonList(nullValue(name));
+      return field(name, Value.nullValue());
     }
 
     // exception
@@ -240,7 +187,7 @@ public interface Field {
      * @return a field.
      */
     default Field exception(Throwable t) {
-      return new DefaultField(EXCEPTION, Value.exception(t));
+      return field(EXCEPTION, Value.exception(t));
     }
 
     /**
@@ -251,7 +198,84 @@ public interface Field {
      * @return a field.
      */
     default Field exception(String name, Throwable t) {
-      return new DefaultField(name, Value.exception(t));
+      return field(name, Value.exception(t));
+    }
+
+    /**
+     * Creates a list of fields out of a name and a raw string value.
+     *
+     * @param name the name of the field.
+     * @param value the value of the field.
+     * @return a list containing a single field.
+     */
+    default List<Field> onlyString(String name, String value) {
+      return only(string(name, value));
+    }
+
+    /**
+     * Creates a singleton list of fields out of a name and a raw number value.
+     *
+     * @param name the name of the field.
+     * @param value the value of the field.
+     * @return a list containing a single field.
+     */
+    default List<Field> onlyNumber(String name, Number value) {
+      return only(number(name, value));
+    }
+
+    /**
+     * Creates a singleton list of fields out of a name and a raw boolean value.
+     *
+     * @param name the name of the field.
+     * @param value the value of the field.
+     * @return a list containing a single field.
+     */
+    default List<Field> onlyBool(String name, Boolean value) {
+      return only(bool(name, value));
+    }
+
+    /**
+     * Creates a singleton list of an array field out of a name and array values.
+     *
+     * @param name the name of the field.
+     * @param values the values.
+     * @return a list containing a single field.
+     */
+    default List<Field> onlyArray(String name, Value<?>... values) {
+      return only(array(name, values));
+    }
+
+    /**
+     * Creates a singleton list of an array field out of a name and a list of values.
+     *
+     * @param name the name of the field.
+     * @param values the values.
+     * @return a list containing a single field.
+     */
+    default List<Field> onlyArray(String name, List<Value<?>> values) {
+      return only(array(name, values));
+    }
+
+    /**
+     * Creates a singleton list of an object out of a name and array values.
+     *
+     * @param name the name of the field.
+     * @param values the values.
+     * @return a list containing a single field.
+     */
+    default List<Field> onlyObject(String name, Field... values) {
+      return only(object(name, values));
+    }
+
+    /**
+     * Creates a singleton list of an object out of a name and a list of values.
+     *
+     * @param name the name of the field.
+     * @param values the values.
+     * @return a list containing a single field.
+     */
+    default List<Field> onlyObject(String name, List<Field> values) {
+      return only(object(name, values));
     }
 
     /**
@@ -261,7 +285,7 @@ public interface Field {
      * @return a list containing a single field.
      */
     default List<Field> onlyException(Throwable t) {
-      return singletonList(exception(t));
+      return only(exception(t));
     }
 
     /**
@@ -272,34 +296,7 @@ public interface Field {
      * @return a list containing a single field.
      */
     default List<Field> onlyException(String name, Throwable t) {
-      return singletonList(exception(name, t));
-    }
-
-    /** The DefaultField class. This is an implementation detail of Field. */
-    final class DefaultField implements Field {
-      private final String name;
-      private final Value<?> value;
-
-      private static final Formatter formatter = new Formatter() {};
-
-      public DefaultField(String name, Value<?> value) {
-        this.name = name;
-        this.value = value;
-      }
-
-      @Override
-      public String name() {
-        return name;
-      }
-
-      @Override
-      public Value<?> value() {
-        return value;
-      }
-
-      public String toString() {
-        return formatter.fieldToString(this);
-      }
+      return only(exception(name, t));
     }
   }
 
@@ -321,7 +318,6 @@ public interface Field {
    * @param <V> the raw type of the underling value.
    */
   abstract class Value<V> {
-    private static final Formatter formatter = new Formatter() {};
 
     protected Value() {}
 
@@ -335,7 +331,11 @@ public interface Field {
     public abstract ValueType type();
 
     public String toString() {
-      return formatter.valueToString(this);
+      return valueToString(this);
+    }
+
+    private String valueToString(Value<?> v) {
+      return v.raw() == null ? "null" : v.raw().toString();
     }
 
     /**
@@ -572,19 +572,6 @@ public interface Field {
       public Throwable raw() {
         return raw;
       }
-    }
-  }
-
-  // Internal formatter... at some point might be worth exposing this through SPI.
-  // This may be important for key=value vs just plain value and logfmt line oriented data.
-  interface Formatter {
-    default String fieldToString(Field field) {
-      String name = field.name();
-      return name + "=" + field.value();
-    }
-
-    default <V> String valueToString(Value<V> v) {
-      return v.raw() == null ? "null" : v.raw().toString();
     }
   }
 }

--- a/api/src/main/java/com/tersesystems/echopraxia/Formatter.java
+++ b/api/src/main/java/com/tersesystems/echopraxia/Formatter.java
@@ -1,0 +1,8 @@
+package com.tersesystems.echopraxia;
+
+// Internal formatter... at some point might be worth exposing this through SPI.
+// This may be important for key=value vs just plain value and logfmt line oriented data.
+// For now, don't expose it anywhere.
+interface Formatter {
+  String fieldToString(Field field);
+}

--- a/api/src/main/java/com/tersesystems/echopraxia/KeyValueField.java
+++ b/api/src/main/java/com/tersesystems/echopraxia/KeyValueField.java
@@ -1,0 +1,46 @@
+package com.tersesystems.echopraxia;
+
+/**
+ * The KeyValueField class.
+ *
+ * <p>This is a field that prints out key=value to a message template.
+ */
+public final class KeyValueField implements Field {
+
+  private static final Formatter formatter =
+      field -> {
+        String name = field.name();
+        return name + "=" + field.value();
+      };
+
+  private final String name;
+  private final Value<?> value;
+
+  // package private builder
+  static final Field.Builder keyValueFieldBuilder =
+      new Field.Builder() {
+        @Override
+        public Field field(String name, Value<?> value) {
+          return new KeyValueField(name, value);
+        }
+      };
+
+  public KeyValueField(String name, Value<?> value) {
+    this.name = name;
+    this.value = value;
+  }
+
+  @Override
+  public String name() {
+    return name;
+  }
+
+  @Override
+  public Value<?> value() {
+    return value;
+  }
+
+  public String toString() {
+    return formatter.fieldToString(this);
+  }
+}

--- a/api/src/main/java/com/tersesystems/echopraxia/Logger.java
+++ b/api/src/main/java/com/tersesystems/echopraxia/Logger.java
@@ -20,16 +20,12 @@ public class Logger<FB extends Field.Builder> {
     this.fieldBuilder = fieldBuilder;
   }
 
-  /**
-   * @return the internal core logger.
-   */
+  /** @return the internal core logger. */
   public CoreLogger core() {
     return core;
   }
 
-  /**
-   * @return the field builder.
-   */
+  /** @return the field builder. */
   public FB fieldBuilder() {
     return fieldBuilder;
   }
@@ -86,9 +82,8 @@ public class Logger<FB extends Field.Builder> {
   }
 
   /**
-   * Creates a new logger with fields using a one-off
-   * field builder for the function that is <b>not</b> passed through to the new
-   * logger.
+   * Creates a new logger with fields using a one-off field builder for the function that is
+   * <b>not</b> passed through to the new logger.
    *
    * @param ctxBuilderF the given function producing fields from a field builder.
    * @param ctxBuilder the field builder to use for the function.
@@ -101,12 +96,10 @@ public class Logger<FB extends Field.Builder> {
     return new Logger<>(coreLogger, fieldBuilder);
   }
 
-  //------------------------------------------------------------------------
+  // ------------------------------------------------------------------------
   // TRACE
 
-  /**
-   * @return true if the logger level is TRACE or higher.
-   */
+  /** @return true if the logger level is TRACE or higher. */
   public boolean isTraceEnabled() {
     return core().isEnabled(TRACE);
   }
@@ -142,7 +135,7 @@ public class Logger<FB extends Field.Builder> {
    * Logs statement at TRACE level with exception.
    *
    * @param message the message.
-   * @param e       the given exception.
+   * @param e the given exception.
    */
   public void trace(String message, Throwable e) {
     core().log(TRACE, message, e);
@@ -174,18 +167,16 @@ public class Logger<FB extends Field.Builder> {
    *
    * @param condition the given condition.
    * @param message the message.
-   * @param e       the given exception.
+   * @param e the given exception.
    */
   public void trace(Condition condition, String message, Throwable e) {
     core().log(TRACE, condition, message, e);
   }
 
-  //------------------------------------------------------------------------
+  // ------------------------------------------------------------------------
   // DEBUG
 
-  /**
-   * @return true if the logger level is DEBUG or higher.
-   */
+  /** @return true if the logger level is DEBUG or higher. */
   public boolean isDebugEnabled() {
     return core().isEnabled(DEBUG);
   }
@@ -221,7 +212,7 @@ public class Logger<FB extends Field.Builder> {
    * Logs statement at DEBUG level with exception.
    *
    * @param message the message.
-   * @param e       the given exception.
+   * @param e the given exception.
    */
   public void debug(String message, Throwable e) {
     core().log(DEBUG, message, e);
@@ -253,18 +244,16 @@ public class Logger<FB extends Field.Builder> {
    *
    * @param condition the given condition.
    * @param message the message.
-   * @param e       the given exception.
+   * @param e the given exception.
    */
   public void debug(Condition condition, String message, Throwable e) {
     core().log(DEBUG, condition, message, e);
   }
 
-  //------------------------------------------------------------------------
+  // ------------------------------------------------------------------------
   // INFO
 
-  /**
-   * @return true if the logger level is INFO or higher.
-   */
+  /** @return true if the logger level is INFO or higher. */
   public boolean isInfoEnabled() {
     return core().isEnabled(INFO);
   }
@@ -300,7 +289,7 @@ public class Logger<FB extends Field.Builder> {
    * Logs statement at INFO level with exception.
    *
    * @param message the message.
-   * @param e       the given exception.
+   * @param e the given exception.
    */
   public void info(String message, Throwable e) {
     core().log(INFO, message, e);
@@ -332,18 +321,16 @@ public class Logger<FB extends Field.Builder> {
    *
    * @param condition the given condition.
    * @param message the message.
-   * @param e       the given exception.
+   * @param e the given exception.
    */
   public void info(Condition condition, String message, Throwable e) {
     core().log(INFO, condition, message, e);
   }
 
-  //------------------------------------------------------------------------
+  // ------------------------------------------------------------------------
   // WARN
 
-  /**
-   * @return true if the logger level is WARN or higher.
-   */
+  /** @return true if the logger level is WARN or higher. */
   public boolean isWarnEnabled() {
     return core().isEnabled(WARN);
   }
@@ -379,7 +366,7 @@ public class Logger<FB extends Field.Builder> {
    * Logs statement at WARN level with exception.
    *
    * @param message the message.
-   * @param e       the given exception.
+   * @param e the given exception.
    */
   public void warn(String message, Throwable e) {
     core().log(WARN, message, e);
@@ -411,18 +398,16 @@ public class Logger<FB extends Field.Builder> {
    *
    * @param condition the given condition.
    * @param message the message.
-   * @param e       the given exception.
+   * @param e the given exception.
    */
   public void warn(Condition condition, String message, Throwable e) {
     core().log(WARN, condition, message, e);
   }
 
-  //------------------------------------------------------------------------
+  // ------------------------------------------------------------------------
   // ERROR
 
-  /**
-   * @return true if the logger level is ERROR or higher.
-   */
+  /** @return true if the logger level is ERROR or higher. */
   public boolean isErrorEnabled() {
     return core().isEnabled(ERROR);
   }
@@ -458,7 +443,7 @@ public class Logger<FB extends Field.Builder> {
    * Logs statement at INFO level with exception.
    *
    * @param message the message.
-   * @param e       the given exception.
+   * @param e the given exception.
    */
   public void error(String message, Throwable e) {
     core().log(ERROR, message, e);
@@ -490,10 +475,9 @@ public class Logger<FB extends Field.Builder> {
    *
    * @param condition the given condition.
    * @param message the message.
-   * @param e       the given exception.
+   * @param e the given exception.
    */
   public void error(Condition condition, String message, Throwable e) {
     core().log(ERROR, condition, message, e);
   }
-
 }

--- a/api/src/main/java/com/tersesystems/echopraxia/LoggerFactory.java
+++ b/api/src/main/java/com/tersesystems/echopraxia/LoggerFactory.java
@@ -5,7 +5,7 @@ import com.tersesystems.echopraxia.core.CoreLogger;
 import com.tersesystems.echopraxia.core.CoreLoggerFactory;
 
 /**
- * The LoggerFactory class.  This is used to create the appropriate `Logger`.
+ * The LoggerFactory class. This is used to create the appropriate `Logger`.
  *
  * <p>{@code private static final Logger logger = LoggerFactory.getLogger(); }
  */

--- a/example/src/main/java/example/Main.java
+++ b/example/src/main/java/example/Main.java
@@ -16,9 +16,11 @@ public class Main {
 
   private Date lastAccessedDate = new Date();
 
+  private static final MyFieldBuilder myFieldBuilder = new MyFieldBuilder();
+
   // More often you'll want to create a logger with your own domain objects and render those.
   // So we start with the basic logger...
-  //   ...and add a custom `BuilderWithDate` as the field builder...
+  //   ...and add a custom field builder...
   //   ...then add a date to the logger's context.
   //
   // Here, `last_accessed_date` will be rendered with every log entry, but will
@@ -28,7 +30,7 @@ public class Main {
   // belongs to an object instance.
   private final Logger<MyFieldBuilder> logger =
       basicLogger
-          .withFieldBuilder(MyFieldBuilder.class)
+          .withFieldBuilder(myFieldBuilder)
           .withFields(fb -> fb.onlyDate("last_accessed_date", lastAccessedDate));
 
   public static void main(String[] args) {

--- a/log4j/src/test/java/com/tersesystems/echopraxia/log4j/LoggerTest.java
+++ b/log4j/src/test/java/com/tersesystems/echopraxia/log4j/LoggerTest.java
@@ -3,7 +3,6 @@ package com.tersesystems.echopraxia.log4j;
 import com.tersesystems.echopraxia.Field;
 import com.tersesystems.echopraxia.Logger;
 import com.tersesystems.echopraxia.LoggerFactory;
-import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -24,7 +23,7 @@ public class LoggerTest {
         fb -> {
           final Field field1 = fb.string("key1", "value1");
           final Field field2 = fb.string("key2", "value2");
-          return fb.onlyObject("random_object", Arrays.asList(field1, field2));
+          return fb.onlyObject("random_object", field1, field2);
         });
   }
 
@@ -33,17 +32,16 @@ public class LoggerTest {
     Logger<?> logger = LoggerFactory.getLogger(getClass());
     logger.info(
         "my argument is {}",
-        fb -> {
-          return Arrays.asList( //
-              fb.object(
-                  "object1", //
-                  fb.string("key1", "value1"),
-                  fb.string("key2", "value2")), //
-              fb.object(
-                  "object2", //
-                  fb.string("key3", "value3"),
-                  fb.string("key4", "value4")));
-        });
+        fb ->
+            fb.list(
+                fb.object(
+                    "object1", //
+                    fb.string("key1", "value1"),
+                    fb.string("key2", "value2")),
+                fb.object(
+                    "object2", //
+                    fb.string("key3", "value3"),
+                    fb.string("key4", "value4"))));
   }
 
   @Test

--- a/logstash/src/test/java/com/tersesystems/echopraxia/logstash/LoggerTest.java
+++ b/logstash/src/test/java/com/tersesystems/echopraxia/logstash/LoggerTest.java
@@ -30,9 +30,7 @@ class LoggerTest extends TestBase {
     Logger<?> logger = getLogger();
     logger.debug(
         "hello {}, you are {}, citizen status {}",
-        fb ->
-            Arrays.asList(
-                fb.string("name", "will"), fb.number("age", 13), fb.bool("citizen", true)));
+        fb -> fb.list(fb.string("name", "will"), fb.number("age", 13), fb.bool("citizen", true)));
 
     final ListAppender<ILoggingEvent> listAppender = getListAppender();
     final ILoggingEvent event = listAppender.list.get(0);

--- a/scripting/src/test/java/com/tersesystems/echopraxia/scripting/ScriptConditionTest.java
+++ b/scripting/src/test/java/com/tersesystems/echopraxia/scripting/ScriptConditionTest.java
@@ -32,7 +32,7 @@ public class ScriptConditionTest {
     Condition condition = ScriptCondition.create(false, buildScript(), Throwable::printStackTrace);
     Logger<?> logger = LoggerFactory.getLogger(getClass()).withCondition(condition);
     logger
-        .withFields(bf -> bf.onlyString("correlation_id", "match"))
+        .withFields(fb -> fb.only(fb.string("correlation_id", "match")))
         .info("data of interest found");
 
     ListAppender<ILoggingEvent> listAppender = getListAppender();
@@ -48,7 +48,7 @@ public class ScriptConditionTest {
 
     Logger<?> logger = LoggerFactory.getLogger(getClass()).withCondition(condition);
     logger
-        .withFields(bf -> bf.onlyException(new RuntimeException("testing")))
+        .withFields(fb -> fb.only(fb.exception(new RuntimeException("testing"))))
         .info("data of interest found");
 
     ListAppender<ILoggingEvent> listAppender = getListAppender();
@@ -64,7 +64,7 @@ public class ScriptConditionTest {
 
     Logger<?> logger = LoggerFactory.getLogger(getClass()).withCondition(condition);
     logger
-        .withFields(bf -> bf.onlyString("correlation_id", "match"))
+        .withFields(bf -> bf.only(bf.string("correlation_id", "match")))
         .info("data of interest found");
 
     ListAppender<ILoggingEvent> listAppender = getListAppender();

--- a/semantic/src/test/java/com/tersesystems/echopraxia/semantic/SemanticLoggerTest.java
+++ b/semantic/src/test/java/com/tersesystems/echopraxia/semantic/SemanticLoggerTest.java
@@ -9,7 +9,6 @@ import ch.qos.logback.core.read.ListAppender;
 import com.tersesystems.echopraxia.Field;
 import com.tersesystems.echopraxia.core.CoreLoggerFactory;
 import com.tersesystems.echopraxia.logstash.LogstashCoreLogger;
-import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -34,7 +33,7 @@ public class SemanticLoggerTest {
             getClass(),
             Person.class,
             person -> "person.name = {}, person.age = {}",
-            p -> b -> Arrays.asList(b.string("name", p.name), b.number("age", p.age)));
+            p -> b -> b.list(b.string("name", p.name), b.number("age", p.age)));
 
     Person eloise = new Person("Eloise", 1);
     logger.info(eloise);
@@ -53,7 +52,7 @@ public class SemanticLoggerTest {
             coreLogger.withMarkers(MarkerFactory.getMarker("SECURITY")),
             Person.class,
             person -> "person.name = {}, person.age = {}",
-            p -> b -> Arrays.asList(b.string("name", p.name), b.number("age", p.age)),
+            p -> b -> b.list(b.string("name", p.name), b.number("age", p.age)),
             Field.Builder.instance());
 
     Person eloise = new Person("Eloise", 1);


### PR DESCRIPTION
* Make key=value more explicit by adding `KeyValueField`
* Add `fb.only`and `fb.list` as wrappers around fields for ease of use
* Add a `field` method that wraps field instantiation so it's possible to use a different instance.