### PR TITLE
Add better null checking throughout

### DIFF
--- a/api/src/main/java/com/tersesystems/echopraxia/Constants.java
+++ b/api/src/main/java/com/tersesystems/echopraxia/Constants.java
@@ -1,9 +1,14 @@
 package com.tersesystems.echopraxia;
 
+import java.util.concurrent.atomic.LongAdder;
 import org.jetbrains.annotations.NotNull;
 
 // Some package private constants
 class Constants {
+
+  public static final String ECHOPRAXIA_UNKNOWN = "echopraxia-unknown-";
+
+  public static final LongAdder unknownFieldAdder = new LongAdder();
 
   private static final Field.Builder builderInstance = new Field.Builder() {};
 
@@ -19,8 +24,8 @@ class Constants {
     private final Value<?> value;
 
     public DefaultValueField(String name, Value<?> value) {
-      this.name = name;
-      this.value = value;
+      this.name = requireName(name);
+      this.value = requireValue(value);
     }
 
     @Override
@@ -44,8 +49,8 @@ class Constants {
     private final Value<?> value;
 
     public DefaultKeyValueField(String name, Value<?> value) {
-      this.name = name;
-      this.value = value;
+      this.name = requireName(name);
+      this.value = requireValue(value);
     }
 
     @Override
@@ -61,5 +66,21 @@ class Constants {
     public String toString() {
       return name + "=" + value;
     }
+  }
+
+  // construct a field name so that json is happy and keep going.
+  private static String requireName(String name) {
+    if (name != null) {
+      return name;
+    }
+    unknownFieldAdder.increment();
+    return ECHOPRAXIA_UNKNOWN + unknownFieldAdder.longValue();
+  }
+
+  private static Field.Value<?> requireValue(Field.Value<?> value) {
+    if (value != null) {
+      return value;
+    }
+    return Field.Value.nullValue();
   }
 }

--- a/api/src/main/java/com/tersesystems/echopraxia/Constants.java
+++ b/api/src/main/java/com/tersesystems/echopraxia/Constants.java
@@ -1,5 +1,7 @@
 package com.tersesystems.echopraxia;
 
+import org.jetbrains.annotations.NotNull;
+
 // Some package private constants
 class Constants {
 
@@ -22,12 +24,12 @@ class Constants {
     }
 
     @Override
-    public String name() {
+    public @NotNull String name() {
       return name;
     }
 
     @Override
-    public Value<?> value() {
+    public @NotNull Value<?> value() {
       return value;
     }
 
@@ -47,12 +49,12 @@ class Constants {
     }
 
     @Override
-    public String name() {
+    public @NotNull String name() {
       return name;
     }
 
     @Override
-    public Value<?> value() {
+    public @NotNull Value<?> value() {
       return value;
     }
 

--- a/api/src/main/java/com/tersesystems/echopraxia/Field.java
+++ b/api/src/main/java/com/tersesystems/echopraxia/Field.java
@@ -1,5 +1,6 @@
 package com.tersesystems.echopraxia;
 
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 
 import com.tersesystems.echopraxia.Constants.DefaultKeyValueField;
@@ -9,6 +10,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * The Field interface. This is a core part of structured data, and consists of a name and a Value,
@@ -25,6 +28,7 @@ public interface Field {
    *
    * @return the field name.
    */
+  @NotNull
   String name();
 
   /**
@@ -32,6 +36,7 @@ public interface Field {
    *
    * @return the field value.
    */
+  @NotNull
   Value<?> value();
 
   /**
@@ -44,7 +49,7 @@ public interface Field {
   interface Builder {
     String EXCEPTION = "exception";
 
-    static Builder instance() {
+    static @NotNull Builder instance() {
       return Constants.builder();
     }
 
@@ -53,11 +58,12 @@ public interface Field {
      *
      * <p>{@code fb.only(fb.string("correlation_id", "match"))}
      *
-     * @param field the given field
+     * @param field the given field, can be null in which case an empty list is returned.
      * @return a list containing a single field element.
      */
-    default List<Field> only(Field field) {
-      return singletonList(field);
+    @NotNull
+    default List<Field> only(@Nullable Field field) {
+      return (field == null) ? emptyList() : singletonList(field);
     }
 
     /**
@@ -68,6 +74,7 @@ public interface Field {
      * @param fields the given fields
      * @return a list containing the fields.
      */
+    @NotNull
     default List<Field> list(Field... fields) {
       return Arrays.asList(fields);
     }
@@ -82,7 +89,8 @@ public interface Field {
      * @param value the field value
      * @return the field.
      */
-    default Field value(String name, Value<?> value) {
+    @NotNull
+    default Field value(@NotNull String name, @NotNull Value<?> value) {
       return new DefaultValueField(name, value);
     }
 
@@ -96,7 +104,8 @@ public interface Field {
      * @param value the field value
      * @return the field.
      */
-    default Field keyValue(String name, Value<?> value) {
+    @NotNull
+    default Field keyValue(@NotNull String name, @NotNull Value<?> value) {
       return new DefaultKeyValueField(name, value);
     }
 
@@ -110,7 +119,8 @@ public interface Field {
      * @param value the value of the field.
      * @return the field.
      */
-    default Field string(String name, String value) {
+    @NotNull
+    default Field string(@NotNull String name, @NotNull String value) {
       return value(name, Value.string(value));
     }
 
@@ -121,7 +131,8 @@ public interface Field {
      * @param value the value of the field.
      * @return the field.
      */
-    default Field string(String name, Value.StringValue value) {
+    @NotNull
+    default Field string(@NotNull String name, @NotNull Value.StringValue value) {
       return value(name, value);
     }
 
@@ -132,7 +143,8 @@ public interface Field {
      * @param value the value of the field.
      * @return a list containing a single field.
      */
-    default List<Field> onlyString(String name, String value) {
+    @NotNull
+    default List<Field> onlyString(@NotNull String name, @NotNull String value) {
       return only(string(name, value));
     }
 
@@ -143,7 +155,8 @@ public interface Field {
      * @param value the value of the field.
      * @return a list containing a single field.
      */
-    default List<Field> onlyString(String name, Value.StringValue value) {
+    @NotNull
+    default List<Field> onlyString(@NotNull String name, @NotNull Value.StringValue value) {
       return only(string(name, value));
     }
 
@@ -157,7 +170,8 @@ public interface Field {
      * @param value the value of the field.
      * @return a list containing a single field.
      */
-    default Field number(String name, Number value) {
+    @NotNull
+    default Field number(@NotNull String name, @NotNull Number value) {
       return value(name, Value.number(value));
     }
 
@@ -168,7 +182,8 @@ public interface Field {
      * @param value the value of the field.
      * @return a list containing a single field.
      */
-    default Field number(String name, Value.NumberValue value) {
+    @NotNull
+    default Field number(@NotNull String name, @NotNull Value.NumberValue value) {
       return value(name, value);
     }
 
@@ -179,7 +194,8 @@ public interface Field {
      * @param value the value of the field.
      * @return a list containing a single field.
      */
-    default List<Field> onlyNumber(String name, Number value) {
+    @NotNull
+    default List<Field> onlyNumber(@NotNull String name, @NotNull Number value) {
       return only(number(name, value));
     }
 
@@ -190,7 +206,8 @@ public interface Field {
      * @param value the value of the field.
      * @return a list containing a single field.
      */
-    default List<Field> onlyNumber(String name, Value.NumberValue value) {
+    @NotNull
+    default List<Field> onlyNumber(@NotNull String name, @NotNull Value.NumberValue value) {
       return only(number(name, value));
     }
 
@@ -204,7 +221,8 @@ public interface Field {
      * @param value the value of the field.
      * @return a list containing a single field.
      */
-    default Field bool(String name, Boolean value) {
+    @NotNull
+    default Field bool(@NotNull String name, @NotNull Boolean value) {
       return value(name, Value.bool(value));
     }
 
@@ -215,7 +233,8 @@ public interface Field {
      * @param value the value of the field.
      * @return a list containing a single field.
      */
-    default Field bool(String name, Value.BooleanValue value) {
+    @NotNull
+    default Field bool(@NotNull String name, @NotNull Value.BooleanValue value) {
       return value(name, value);
     }
 
@@ -226,7 +245,8 @@ public interface Field {
      * @param value the value of the field.
      * @return a list containing a single field.
      */
-    default List<Field> onlyBool(String name, Boolean value) {
+    @NotNull
+    default List<Field> onlyBool(@NotNull String name, @NotNull Boolean value) {
       return only(bool(name, value));
     }
 
@@ -237,7 +257,8 @@ public interface Field {
      * @param value the value of the field.
      * @return a list containing a single field.
      */
-    default List<Field> onlyBool(String name, Value.BooleanValue value) {
+    @NotNull
+    default List<Field> onlyBool(@NotNull String name, @NotNull Value.BooleanValue value) {
       return only(bool(name, value));
     }
 
@@ -251,7 +272,8 @@ public interface Field {
      * @param values the array of values.
      * @return a list containing a single field.
      */
-    default Field array(String name, Value.ObjectValue... values) {
+    @NotNull
+    default Field array(@NotNull String name, @NotNull Value.ObjectValue... values) {
       return keyValue(name, Value.array(values));
     }
 
@@ -262,7 +284,8 @@ public interface Field {
      * @param values the array of values.
      * @return a list containing a single field.
      */
-    default Field array(String name, String... values) {
+    @NotNull
+    default Field array(@NotNull String name, String... values) {
       return keyValue(name, Value.array(values));
     }
 
@@ -273,7 +296,8 @@ public interface Field {
      * @param values the array of values.
      * @return a list containing a single field.
      */
-    default Field array(String name, Number... values) {
+    @NotNull
+    default Field array(@NotNull String name, Number... values) {
       return keyValue(name, Value.array(values));
     }
 
@@ -284,7 +308,8 @@ public interface Field {
      * @param values the array of values.
      * @return a list containing a single field.
      */
-    default Field array(String name, Boolean... values) {
+    @NotNull
+    default Field array(@NotNull String name, Boolean... values) {
       return keyValue(name, Value.array(values));
     }
 
@@ -297,7 +322,8 @@ public interface Field {
      * @param value the array value.
      * @return a list containing a single field.
      */
-    default Field array(String name, Value.ArrayValue value) {
+    @NotNull
+    default Field array(@NotNull String name, @NotNull Value.ArrayValue value) {
       // Don't allow Value.ArrayValue... it's far too easy to double nest an array.
       return keyValue(name, value);
     }
@@ -309,7 +335,8 @@ public interface Field {
      * @param values the values.
      * @return a list containing a single field.
      */
-    default List<Field> onlyArray(String name, Value.ObjectValue... values) {
+    @NotNull
+    default List<Field> onlyArray(@NotNull String name, @NotNull Value.ObjectValue... values) {
       return only(array(name, values));
     }
 
@@ -320,7 +347,8 @@ public interface Field {
      * @param values the values.
      * @return a list containing a single field.
      */
-    default List<Field> onlyArray(String name, String... values) {
+    @NotNull
+    default List<Field> onlyArray(@NotNull String name, String... values) {
       return only(array(name, values));
     }
 
@@ -331,7 +359,8 @@ public interface Field {
      * @param values the values.
      * @return a list containing a single field.
      */
-    default List<Field> onlyArray(String name, Number... values) {
+    @NotNull
+    default List<Field> onlyArray(@NotNull String name, Number... values) {
       return only(array(name, values));
     }
 
@@ -342,7 +371,8 @@ public interface Field {
      * @param values the values.
      * @return a list containing a single field.
      */
-    default List<Field> onlyArray(String name, Boolean... values) {
+    @NotNull
+    default List<Field> onlyArray(@NotNull String name, Boolean... values) {
       return only(array(name, values));
     }
 
@@ -355,7 +385,8 @@ public interface Field {
      * @param value the array value.
      * @return a list containing a single field.
      */
-    default List<Field> onlyArray(String name, Value.ArrayValue value) {
+    @NotNull
+    default List<Field> onlyArray(@NotNull String name, @NotNull Value.ArrayValue value) {
       return only(array(name, value));
     }
 
@@ -369,7 +400,8 @@ public interface Field {
      * @param values the values.
      * @return a single field.
      */
-    default Field object(String name, Field... values) {
+    @NotNull
+    default Field object(@NotNull String name, Field... values) {
       return keyValue(name, Value.object(values));
     }
 
@@ -380,7 +412,8 @@ public interface Field {
      * @param values the values.
      * @return a field.
      */
-    default Field object(String name, List<Field> values) {
+    @NotNull
+    default Field object(@NotNull String name, @NotNull List<Field> values) {
       return keyValue(name, Value.object(values));
     }
 
@@ -391,7 +424,8 @@ public interface Field {
      * @param value the value.
      * @return a field.
      */
-    default Field object(String name, Value.ObjectValue value) {
+    @NotNull
+    default Field object(@NotNull String name, @NotNull Value.ObjectValue value) {
       // limited to object specifically -- if you want object or null,
       // use `value` or `keyValue`
       return keyValue(name, value);
@@ -404,7 +438,8 @@ public interface Field {
      * @param values the values.
      * @return a list containing a single field.
      */
-    default List<Field> onlyObject(String name, Field... values) {
+    @NotNull
+    default List<Field> onlyObject(@NotNull String name, @NotNull Field... values) {
       return only(object(name, values));
     }
 
@@ -415,7 +450,8 @@ public interface Field {
      * @param values the values.
      * @return a list containing a single field.
      */
-    default List<Field> onlyObject(String name, List<Field> values) {
+    @NotNull
+    default List<Field> onlyObject(@NotNull String name, @NotNull List<Field> values) {
       return only(object(name, values));
     }
 
@@ -426,7 +462,8 @@ public interface Field {
      * @param value the object values.
      * @return a list containing a single field.
      */
-    default List<Field> onlyObject(String name, Value.ObjectValue value) {
+    @NotNull
+    default List<Field> onlyObject(@NotNull String name, @NotNull Value.ObjectValue value) {
       return only(object(name, value));
     }
 
@@ -439,7 +476,8 @@ public interface Field {
      * @param t the exception.
      * @return a field.
      */
-    default Field exception(Throwable t) {
+    @NotNull
+    default Field exception(@NotNull Throwable t) {
       return keyValue(EXCEPTION, Value.exception(t));
     }
 
@@ -449,7 +487,8 @@ public interface Field {
      * @param value the exception value.
      * @return a field.
      */
-    default Field exception(Value.ExceptionValue value) {
+    @NotNull
+    default Field exception(@NotNull Value.ExceptionValue value) {
       return keyValue(EXCEPTION, value);
     }
 
@@ -460,7 +499,8 @@ public interface Field {
      * @param t the exception.
      * @return a field.
      */
-    default Field exception(String name, Throwable t) {
+    @NotNull
+    default Field exception(@NotNull String name, @NotNull Throwable t) {
       return keyValue(name, Value.exception(t));
     }
 
@@ -471,7 +511,8 @@ public interface Field {
      * @param value the exception value.
      * @return a field.
      */
-    default Field exception(String name, Value.ExceptionValue value) {
+    @NotNull
+    default Field exception(@NotNull String name, @NotNull Value.ExceptionValue value) {
       return keyValue(name, value);
     }
 
@@ -483,7 +524,8 @@ public interface Field {
      */
     // should probably deprecate this as  logger.error(msg, e) is the ideomatic form over fb ->
     // fb.onlyException(e)
-    default List<Field> onlyException(Throwable t) {
+    @NotNull
+    default List<Field> onlyException(@NotNull Throwable t) {
       return only(exception(t));
     }
 
@@ -496,7 +538,8 @@ public interface Field {
      * @param t the value of the field.
      * @return a list containing a single field.
      */
-    default List<Field> onlyException(Value.ExceptionValue t) {
+    @NotNull
+    default List<Field> onlyException(@NotNull Value.ExceptionValue t) {
       return only(exception(t));
     }
 
@@ -507,7 +550,8 @@ public interface Field {
      * @param value the value of the field.
      * @return a list containing a single field.
      */
-    default List<Field> onlyException(String name, Value.ExceptionValue value) {
+    @NotNull
+    default List<Field> onlyException(@NotNull String name, @NotNull Value.ExceptionValue value) {
       return only(exception(name, value));
     }
 
@@ -520,7 +564,8 @@ public interface Field {
      * @param name the name of the field.
      * @return a field.
      */
-    default Field nullField(String name) {
+    @NotNull
+    default Field nullField(@NotNull String name) {
       return value(name, Value.nullValue());
     }
 
@@ -530,7 +575,8 @@ public interface Field {
      * @param name the name of the field.
      * @return a list containing a single field.
      */
-    default List<Field> onlyNullField(String name) {
+    @NotNull
+    default List<Field> onlyNullField(@NotNull String name) {
       return only(nullField(name));
     }
   }
@@ -567,7 +613,7 @@ public interface Field {
     protected Value() {}
 
     /**
-     * The underlying raw value.
+     * The underlying raw value, may be null in some cases.
      *
      * @return the underlying raw value.
      */
@@ -578,8 +624,10 @@ public interface Field {
      *
      * @return the value type.
      */
+    @NotNull
     public abstract ValueType type();
 
+    @NotNull
     public String toString() {
       return valueToString(this);
     }
@@ -590,10 +638,13 @@ public interface Field {
      * @param v the value
      * @return the value as a string.
      */
-    private static String valueToString(Value<?> v) {
-      if (v.type() == ValueType.NULL) {
+    @NotNull
+    private static String valueToString(@NotNull Value<?> v) {
+      final Object raw = v.raw();
+      if (raw == null) { // if null value or a raw value was set to null, keep going.
         return "null";
       }
+
       // render an object with curly braces to distinguish from array.
       if (v.type() == ValueType.OBJECT) {
         final List<Field> fieldList = ((ObjectValue) v).raw();
@@ -603,37 +654,41 @@ public interface Field {
         b.append("}");
         return b.toString();
       }
-      return v.raw().toString();
+
+      return raw.toString();
     }
 
     /**
      * Wraps a string with a Value.
      *
-     * @param raw the raw string value.
+     * @param value the raw string value.
      * @return the Value
      */
-    public static Value.StringValue string(String raw) {
-      return new StringValue(raw);
+    @NotNull
+    public static Value.StringValue string(@NotNull String value) {
+      return new StringValue(value);
     }
 
     /**
      * Wraps a number with a Value.
      *
-     * @param n the raw number value.
+     * @param value the raw number value.
      * @return the Value
      */
-    public static Value.NumberValue number(Number n) {
-      return new NumberValue(n);
+    @NotNull
+    public static Value.NumberValue number(@NotNull Number value) {
+      return new NumberValue(value);
     }
 
     /**
      * Wraps a boolean with a Value.
      *
-     * @param b the raw boolean value.
+     * @param value the raw boolean value.
      * @return the Value.
      */
-    public static Value.BooleanValue bool(Boolean b) {
-      return new BooleanValue(b);
+    @NotNull
+    public static Value.BooleanValue bool(@NotNull Boolean value) {
+      return new BooleanValue(value);
     }
 
     /**
@@ -641,6 +696,7 @@ public interface Field {
      *
      * @return the Value.
      */
+    @NotNull
     public static Value<?> nullValue() {
       return NullValue.instance;
     }
@@ -651,7 +707,8 @@ public interface Field {
      * @param t the raw exception value.
      * @return the Value.
      */
-    public static Value.ExceptionValue exception(Throwable t) {
+    @NotNull
+    public static Value.ExceptionValue exception(@NotNull Throwable t) {
       return new ExceptionValue(t);
     }
 
@@ -661,6 +718,7 @@ public interface Field {
      * @param values variadic elements of values.
      * @return the Value.
      */
+    @NotNull
     public static Value.ArrayValue array(Value<?>... values) {
       return new ArrayValue(Arrays.asList(values));
     }
@@ -671,7 +729,8 @@ public interface Field {
      * @param values varadic elements of values.
      * @return the Value.
      */
-    public static Value.ArrayValue array(Boolean... values) {
+    @NotNull
+    public static Value.ArrayValue array(Boolean @NotNull ... values) {
       return new ArrayValue(asList(values, Value::bool));
     }
 
@@ -681,7 +740,8 @@ public interface Field {
      * @param values varadic elements of values.
      * @return the Value.
      */
-    public static Value.ArrayValue array(String... values) {
+    @NotNull
+    public static Value.ArrayValue array(String @NotNull ... values) {
       return new ArrayValue(asList(values, Value::string));
     }
 
@@ -691,7 +751,8 @@ public interface Field {
      * @param values varadic elements of values.
      * @return the Value.
      */
-    public static Value.ArrayValue array(Number... values) {
+    @NotNull
+    public static Value.ArrayValue array(Number @NotNull ... values) {
       return new ArrayValue(asList(values, Value::number));
     }
 
@@ -701,7 +762,7 @@ public interface Field {
      * @param values a list of values.
      * @return the Value.
      */
-    public static Value.ArrayValue array(List<Value<?>> values) {
+    public static Value.ArrayValue array(@NotNull List<Value<?>> values) {
       return new ArrayValue(values);
     }
 
@@ -713,7 +774,9 @@ public interface Field {
      * @return the Value.
      * @param <T> the type of object.
      */
-    public static <T> Value.ArrayValue array(Function<T, Value<?>> transform, List<T> values) {
+    @NotNull
+    public static <T> Value.ArrayValue array(
+        @NotNull Function<T, Value<?>> transform, @NotNull List<T> values) {
       return new ArrayValue(asList(values, transform));
     }
 
@@ -725,7 +788,9 @@ public interface Field {
      * @return the Value.
      * @param <T> the type of object.
      */
-    public static <T> Value.ArrayValue array(Function<T, Value<?>> transform, T[] values) {
+    @NotNull
+    public static <T> Value.ArrayValue array(
+        @NotNull Function<T, Value<?>> transform, T @NotNull [] values) {
       return new ArrayValue(asList(values, transform));
     }
 
@@ -735,7 +800,8 @@ public interface Field {
      * @param fields variadic elements of fields.
      * @return the Value.
      */
-    public static Value.ObjectValue object(Field... fields) {
+    @NotNull
+    public static Value.ObjectValue object(Field @NotNull ... fields) {
       return new ObjectValue(Arrays.asList(fields));
     }
 
@@ -745,7 +811,8 @@ public interface Field {
      * @param fields the list of fields.
      * @return the Value.
      */
-    public static Value.ObjectValue object(List<Field> fields) {
+    @NotNull
+    public static Value.ObjectValue object(@NotNull List<Field> fields) {
       return new ObjectValue(fields);
     }
 
@@ -757,7 +824,9 @@ public interface Field {
      * @return the Value.
      * @param <T> THe type of the element
      */
-    public static <T> Value.ObjectValue object(Function<T, Field> transform, T[] values) {
+    @NotNull
+    public static <T> Value.ObjectValue object(
+        @NotNull Function<T, Field> transform, T @NotNull [] values) {
       List<Field> fields = Arrays.stream(values).map(transform).collect(Collectors.toList());
       return new ObjectValue(fields);
     }
@@ -770,7 +839,9 @@ public interface Field {
      * @return the Value.
      * @param <T> the type of the element
      */
-    public static <T> Value.ObjectValue object(Function<T, Field> transform, List<T> values) {
+    @NotNull
+    public static <T> Value.ObjectValue object(
+        @NotNull Function<T, Field> transform, @NotNull List<T> values) {
       List<Field> fields = values.stream().map(transform).collect(Collectors.toList());
       return new ObjectValue(fields);
     }
@@ -784,7 +855,8 @@ public interface Field {
      * @return the value, or null value if the optional is empty.
      */
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-    public static Value<?> optional(Optional<? extends Value<?>> optionalValue) {
+    @NotNull
+    public static Value<?> optional(@NotNull Optional<? extends Value<?>> optionalValue) {
       if (optionalValue.isPresent()) {
         return optionalValue.get();
       }
@@ -799,7 +871,9 @@ public interface Field {
      * @return list of values.
      * @param <T> the raw type
      */
-    private static <T> List<Value<?>> asList(T[] array, Function<T, Value<?>> f) {
+    @NotNull
+    private static <T> List<Value<?>> asList(
+        T @NotNull [] array, @NotNull Function<T, Value<?>> f) {
       return Arrays.stream(array).map(f).collect(Collectors.toList());
     }
 
@@ -811,7 +885,9 @@ public interface Field {
      * @return list of values.
      * @param <T> the raw type
      */
-    private static <T> List<Value<?>> asList(List<T> values, Function<T, Value<?>> f) {
+    @NotNull
+    private static <T> List<Value<?>> asList(
+        @NotNull List<T> values, @NotNull Function<T, Value<?>> f) {
       return values.stream().map(f).collect(Collectors.toList());
     }
 
@@ -823,12 +899,12 @@ public interface Field {
       }
 
       @Override
-      public Boolean raw() {
+      public @NotNull Boolean raw() {
         return this.bool;
       }
 
       @Override
-      public ValueType type() {
+      public @NotNull ValueType type() {
         return ValueType.BOOLEAN;
       }
     }
@@ -841,12 +917,12 @@ public interface Field {
       }
 
       @Override
-      public Number raw() {
+      public @NotNull Number raw() {
         return number;
       }
 
       @Override
-      public ValueType type() {
+      public @NotNull ValueType type() {
         return ValueType.NUMBER;
       }
     }
@@ -859,12 +935,12 @@ public interface Field {
       }
 
       @Override
-      public String raw() {
+      public @NotNull String raw() {
         return s;
       }
 
       @Override
-      public ValueType type() {
+      public @NotNull ValueType type() {
         return ValueType.STRING;
       }
     }
@@ -882,7 +958,7 @@ public interface Field {
       }
 
       @Override
-      public ValueType type() {
+      public @NotNull ValueType type() {
         return ValueType.ARRAY;
       }
     }
@@ -895,7 +971,7 @@ public interface Field {
       }
 
       @Override
-      public ValueType type() {
+      public @NotNull ValueType type() {
         return ValueType.OBJECT;
       }
 
@@ -905,21 +981,21 @@ public interface Field {
       }
     }
 
-    public static final class NullValue extends Value<Object> {
+    public static final class NullValue extends Value<Void> {
       // Should not be able to instantiate this outside of class.
       private NullValue() {}
 
       @Override
-      public Object raw() {
-        return null;
+      public Void raw() {
+        return null; // can't really return an instance of void :-)
       }
 
       @Override
-      public ValueType type() {
+      public @NotNull ValueType type() {
         return ValueType.NULL;
       }
 
-      public static NullValue instance = new NullValue();
+      public static @NotNull NullValue instance = new NullValue();
     }
 
     public static final class ExceptionValue extends Value<Throwable> {
@@ -930,7 +1006,7 @@ public interface Field {
       }
 
       @Override
-      public ValueType type() {
+      public @NotNull ValueType type() {
         return ValueType.EXCEPTION;
       }
 

--- a/api/src/main/java/com/tersesystems/echopraxia/Field.java
+++ b/api/src/main/java/com/tersesystems/echopraxia/Field.java
@@ -7,6 +7,7 @@ import com.tersesystems.echopraxia.Constants.DefaultKeyValueField;
 import com.tersesystems.echopraxia.Constants.DefaultValueField;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -770,13 +771,14 @@ public interface Field {
      * Takes a list of objects and a transform function that maps from T to a value.
      *
      * @param values a list of values.
-     * @param transform the tranform function
+     * @param transform the transform function
      * @return the Value.
      * @param <T> the type of object.
      */
     @NotNull
     public static <T> Value.ArrayValue array(
         @NotNull Function<T, Value<?>> transform, @NotNull List<T> values) {
+      // Nulls are allowed in array.
       return new ArrayValue(asList(values, transform));
     }
 
@@ -791,6 +793,7 @@ public interface Field {
     @NotNull
     public static <T> Value.ArrayValue array(
         @NotNull Function<T, Value<?>> transform, T @NotNull [] values) {
+      // nulls are explicitly allowed in array.
       return new ArrayValue(asList(values, transform));
     }
 
@@ -802,7 +805,10 @@ public interface Field {
      */
     @NotNull
     public static Value.ObjectValue object(Field @NotNull ... fields) {
-      return new ObjectValue(Arrays.asList(fields));
+      // Null fields are not allowed.
+      final List<Field> nonNullList =
+          Arrays.stream(fields).filter(Objects::nonNull).collect(Collectors.toList());
+      return new ObjectValue(nonNullList);
     }
 
     /**
@@ -813,7 +819,10 @@ public interface Field {
      */
     @NotNull
     public static Value.ObjectValue object(@NotNull List<Field> fields) {
-      return new ObjectValue(fields);
+      // Null fields are not allowed.
+      final List<Field> nonNullList =
+          fields.stream().filter(Objects::nonNull).collect(Collectors.toList());
+      return new ObjectValue(nonNullList);
     }
 
     /**
@@ -827,7 +836,11 @@ public interface Field {
     @NotNull
     public static <T> Value.ObjectValue object(
         @NotNull Function<T, Field> transform, T @NotNull [] values) {
-      List<Field> fields = Arrays.stream(values).map(transform).collect(Collectors.toList());
+      List<Field> fields =
+          Arrays.stream(values)
+              .map(transform)
+              .filter(Objects::nonNull)
+              .collect(Collectors.toList());
       return new ObjectValue(fields);
     }
 
@@ -842,7 +855,8 @@ public interface Field {
     @NotNull
     public static <T> Value.ObjectValue object(
         @NotNull Function<T, Field> transform, @NotNull List<T> values) {
-      List<Field> fields = values.stream().map(transform).collect(Collectors.toList());
+      List<Field> fields =
+          values.stream().map(transform).filter(Objects::nonNull).collect(Collectors.toList());
       return new ObjectValue(fields);
     }
 
@@ -917,7 +931,7 @@ public interface Field {
       }
 
       @Override
-      public @NotNull Number raw() {
+      public Number raw() {
         return number;
       }
 
@@ -935,7 +949,7 @@ public interface Field {
       }
 
       @Override
-      public @NotNull String raw() {
+      public String raw() {
         return s;
       }
 
@@ -953,7 +967,7 @@ public interface Field {
       }
 
       @Override
-      public List<Value<?>> raw() {
+      public @NotNull List<Value<?>> raw() {
         return raw;
       }
 

--- a/api/src/main/java/com/tersesystems/echopraxia/Logger.java
+++ b/api/src/main/java/com/tersesystems/echopraxia/Logger.java
@@ -1,15 +1,16 @@
 package com.tersesystems.echopraxia;
 
-import com.tersesystems.echopraxia.core.CoreLogger;
+import static com.tersesystems.echopraxia.Level.*;
 
+import com.tersesystems.echopraxia.core.CoreLogger;
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-
-import static com.tersesystems.echopraxia.Level.*;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * An echopraxia logger built around a field builder.
@@ -17,13 +18,17 @@ import static com.tersesystems.echopraxia.Level.*;
  * <p>This class is explicitly designed to be subclassed so that end users can customize it and
  * avoid the parameterized type tax.
  *
- * <p>{@code <pre> public class MyLogger extends Logger&lt;MyFieldBuilder&gt; { protected
- * MyLogger(CoreLogger core, MyFieldBuilder fieldBuilder) { super(core, fieldBuilder); } }
+ * <pre>{@code
+ * public class MyLogger extends Logger<MyFieldBuilder> {
+ *   protected MyLogger(CoreLogger core, MyFieldBuilder fieldBuilder) { super(core, fieldBuilder); }
+ * }
  *
- * <p>static class MyLoggerFactory { public static MyLogger getLogger() { return new
- * MyLogger(CoreLoggerFactory.getLogger(), myFieldBuilder); } }
+ * static class MyLoggerFactory {
+ *   public static MyLogger getLogger() { return new MyLogger(CoreLoggerFactory.getLogger(), myFieldBuilder); }
+ * }
  *
- * <p>MyLogger logger = MyLoggerFactory.getLogger(); </pre> }
+ * MyLogger logger = MyLoggerFactory.getLogger();
+ * }</pre>
  *
  * @param <FB> the field builder type.
  */
@@ -32,17 +37,19 @@ public class Logger<FB extends Field.Builder> {
   protected final CoreLogger core;
   protected final FB fieldBuilder;
 
-  protected Logger(CoreLogger core, FB fieldBuilder) {
+  protected Logger(@NotNull CoreLogger core, @NotNull FB fieldBuilder) {
     this.core = core;
     this.fieldBuilder = fieldBuilder;
   }
 
   /** @return the internal core logger. */
+  @NotNull
   public CoreLogger core() {
     return core;
   }
 
   /** @return the field builder. */
+  @NotNull
   public FB fieldBuilder() {
     return fieldBuilder;
   }
@@ -54,7 +61,8 @@ public class Logger<FB extends Field.Builder> {
    * @param <T> the type of the field builder.
    * @return a new logger using the given field builder.
    */
-  public <T extends Field.Builder> Logger<T> withFieldBuilder(T newBuilder) {
+  @NotNull
+  public <T extends Field.Builder> Logger<T> withFieldBuilder(@NotNull T newBuilder) {
     if (this.fieldBuilder == newBuilder) {
       //noinspection unchecked
       return (Logger<T>) this;
@@ -69,7 +77,8 @@ public class Logger<FB extends Field.Builder> {
    * @param <T> the type of the field builder.
    * @return a new logger using the given field builder.
    */
-  public <T extends Field.Builder> Logger<T> withFieldBuilder(Class<T> newBuilderClass) {
+  @NotNull
+  public <T extends Field.Builder> Logger<T> withFieldBuilder(@NotNull Class<T> newBuilderClass) {
     try {
       final T newInstance = newBuilderClass.getDeclaredConstructor().newInstance();
       return new Logger<>(core(), newInstance);
@@ -90,7 +99,8 @@ public class Logger<FB extends Field.Builder> {
    * @param condition the given condition.
    * @return the new logger.
    */
-  public Logger<FB> withCondition(Condition condition) {
+  @NotNull
+  public Logger<FB> withCondition(@NotNull Condition condition) {
     if (condition == Condition.always()) {
       return this;
     }
@@ -110,17 +120,19 @@ public class Logger<FB extends Field.Builder> {
    * @param f the given function producing fields from a field builder.
    * @return the new logger.
    */
-  public Logger<FB> withFields(Field.BuilderFunction<FB> f) {
+  @NotNull
+  public Logger<FB> withFields(@NotNull Field.BuilderFunction<FB> f) {
     return new Logger<>(core().withFields(f, fieldBuilder), fieldBuilder);
   }
 
   /**
    * Creates a new logger with context fields from thread context / MDC mapped as context fields.
    *
-   * Note that the context map is lazily evaluated on every logging statement.
+   * <p>Note that the context map is lazily evaluated on every logging statement.
    *
    * @return the new logger.
    */
+  @NotNull
   public Logger<FB> withThreadContext() {
     Function<Supplier<Map<String, String>>, Supplier<List<Field>>> mapTransform =
         mapSupplier ->
@@ -143,7 +155,7 @@ public class Logger<FB extends Field.Builder> {
    * @param condition the given condition.
    * @return true if the logger level is TRACE or higher and the condition is met.
    */
-  public boolean isTraceEnabled(Condition condition) {
+  public boolean isTraceEnabled(@NotNull Condition condition) {
     return core().isEnabled(TRACE, condition);
   }
 
@@ -152,7 +164,7 @@ public class Logger<FB extends Field.Builder> {
    *
    * @param message the given message.
    */
-  public void trace(String message) {
+  public void trace(@Nullable String message) {
     core().log(TRACE, message);
   }
 
@@ -162,7 +174,7 @@ public class Logger<FB extends Field.Builder> {
    * @param message the message.
    * @param f the field builder function.
    */
-  public void trace(String message, Field.BuilderFunction<FB> f) {
+  public void trace(@Nullable String message, Field.BuilderFunction<FB> f) {
     core().log(TRACE, message, f, fieldBuilder);
   }
 
@@ -172,7 +184,7 @@ public class Logger<FB extends Field.Builder> {
    * @param message the message.
    * @param e the given exception.
    */
-  public void trace(String message, Throwable e) {
+  public void trace(@Nullable String message, @NotNull Throwable e) {
     core().log(TRACE, message, e);
   }
 
@@ -182,7 +194,7 @@ public class Logger<FB extends Field.Builder> {
    * @param condition the given condition.
    * @param message the message.
    */
-  public void trace(Condition condition, String message) {
+  public void trace(@NotNull Condition condition, @Nullable String message) {
     core().log(TRACE, condition, message);
   }
 
@@ -193,7 +205,10 @@ public class Logger<FB extends Field.Builder> {
    * @param message the message.
    * @param f the field builder function.
    */
-  public void trace(Condition condition, String message, Field.BuilderFunction<FB> f) {
+  public void trace(
+      @NotNull Condition condition,
+      @Nullable String message,
+      @NotNull Field.BuilderFunction<FB> f) {
     core().log(TRACE, condition, message, f, fieldBuilder);
   }
 
@@ -204,7 +219,7 @@ public class Logger<FB extends Field.Builder> {
    * @param message the message.
    * @param e the given exception.
    */
-  public void trace(Condition condition, String message, Throwable e) {
+  public void trace(@NotNull Condition condition, @Nullable String message, @NotNull Throwable e) {
     core().log(TRACE, condition, message, e);
   }
 
@@ -220,7 +235,7 @@ public class Logger<FB extends Field.Builder> {
    * @param condition the given condition.
    * @return true if the logger level is DEBUG or higher and the condition is met.
    */
-  public boolean isDebugEnabled(Condition condition) {
+  public boolean isDebugEnabled(@NotNull Condition condition) {
     return core().isEnabled(DEBUG, condition);
   }
 
@@ -229,7 +244,7 @@ public class Logger<FB extends Field.Builder> {
    *
    * @param message the given message.
    */
-  public void debug(String message) {
+  public void debug(@Nullable String message) {
     core().log(DEBUG, message);
   }
 
@@ -239,7 +254,7 @@ public class Logger<FB extends Field.Builder> {
    * @param message the message.
    * @param f the field builder function.
    */
-  public void debug(String message, Field.BuilderFunction<FB> f) {
+  public void debug(@Nullable String message, @NotNull Field.BuilderFunction<FB> f) {
     core().log(DEBUG, message, f, fieldBuilder);
   }
 
@@ -249,7 +264,7 @@ public class Logger<FB extends Field.Builder> {
    * @param message the message.
    * @param e the given exception.
    */
-  public void debug(String message, Throwable e) {
+  public void debug(@Nullable String message, @NotNull Throwable e) {
     core().log(DEBUG, message, e);
   }
 
@@ -259,7 +274,7 @@ public class Logger<FB extends Field.Builder> {
    * @param condition the given condition.
    * @param message the message.
    */
-  public void debug(Condition condition, String message) {
+  public void debug(@NotNull Condition condition, @Nullable String message) {
     core().log(DEBUG, condition, message);
   }
 
@@ -270,7 +285,10 @@ public class Logger<FB extends Field.Builder> {
    * @param message the message.
    * @param f the field builder function.
    */
-  public void debug(Condition condition, String message, Field.BuilderFunction<FB> f) {
+  public void debug(
+      @NotNull Condition condition,
+      @Nullable String message,
+      @NotNull Field.BuilderFunction<FB> f) {
     core().log(DEBUG, condition, message, f, fieldBuilder);
   }
 
@@ -281,7 +299,7 @@ public class Logger<FB extends Field.Builder> {
    * @param message the message.
    * @param e the given exception.
    */
-  public void debug(Condition condition, String message, Throwable e) {
+  public void debug(@NotNull Condition condition, @Nullable String message, @NotNull Throwable e) {
     core().log(DEBUG, condition, message, e);
   }
 
@@ -297,7 +315,7 @@ public class Logger<FB extends Field.Builder> {
    * @param condition the given condition.
    * @return true if the logger level is INFO or higher and the condition is met.
    */
-  public boolean isInfoEnabled(Condition condition) {
+  public boolean isInfoEnabled(@NotNull Condition condition) {
     return core().isEnabled(INFO, condition);
   }
 
@@ -306,7 +324,7 @@ public class Logger<FB extends Field.Builder> {
    *
    * @param message the given message.
    */
-  public void info(String message) {
+  public void info(@Nullable String message) {
     core().log(INFO, message);
   }
 
@@ -316,7 +334,7 @@ public class Logger<FB extends Field.Builder> {
    * @param message the message.
    * @param f the field builder function.
    */
-  public void info(String message, Field.BuilderFunction<FB> f) {
+  public void info(@Nullable String message, @NotNull Field.BuilderFunction<FB> f) {
     core().log(INFO, message, f, fieldBuilder);
   }
 
@@ -326,7 +344,7 @@ public class Logger<FB extends Field.Builder> {
    * @param message the message.
    * @param e the given exception.
    */
-  public void info(String message, Throwable e) {
+  public void info(@Nullable String message, @NotNull Throwable e) {
     core().log(INFO, message, e);
   }
 
@@ -336,7 +354,7 @@ public class Logger<FB extends Field.Builder> {
    * @param condition the given condition.
    * @param message the message.
    */
-  public void info(Condition condition, String message) {
+  public void info(@NotNull Condition condition, @Nullable String message) {
     core().log(INFO, condition, message);
   }
 
@@ -347,7 +365,10 @@ public class Logger<FB extends Field.Builder> {
    * @param message the message.
    * @param f the field builder function.
    */
-  public void info(Condition condition, String message, Field.BuilderFunction<FB> f) {
+  public void info(
+      @NotNull Condition condition,
+      @Nullable String message,
+      @NotNull Field.BuilderFunction<FB> f) {
     core().log(INFO, condition, message, f, fieldBuilder);
   }
 
@@ -358,7 +379,7 @@ public class Logger<FB extends Field.Builder> {
    * @param message the message.
    * @param e the given exception.
    */
-  public void info(Condition condition, String message, Throwable e) {
+  public void info(@NotNull Condition condition, @Nullable String message, @NotNull Throwable e) {
     core().log(INFO, condition, message, e);
   }
 
@@ -374,7 +395,7 @@ public class Logger<FB extends Field.Builder> {
    * @param condition the given condition.
    * @return true if the logger level is WARN or higher and the condition is met.
    */
-  public boolean isWarnEnabled(Condition condition) {
+  public boolean isWarnEnabled(@NotNull Condition condition) {
     return core().isEnabled(WARN, condition);
   }
 
@@ -383,7 +404,7 @@ public class Logger<FB extends Field.Builder> {
    *
    * @param message the given message.
    */
-  public void warn(String message) {
+  public void warn(@Nullable String message) {
     core().log(WARN, message);
   }
 
@@ -393,7 +414,7 @@ public class Logger<FB extends Field.Builder> {
    * @param message the message.
    * @param f the field builder function.
    */
-  public void warn(String message, Field.BuilderFunction<FB> f) {
+  public void warn(@Nullable String message, @NotNull Field.BuilderFunction<FB> f) {
     core().log(WARN, message, f, fieldBuilder);
   }
 
@@ -403,7 +424,7 @@ public class Logger<FB extends Field.Builder> {
    * @param message the message.
    * @param e the given exception.
    */
-  public void warn(String message, Throwable e) {
+  public void warn(@Nullable String message, @NotNull Throwable e) {
     core().log(WARN, message, e);
   }
 
@@ -413,7 +434,7 @@ public class Logger<FB extends Field.Builder> {
    * @param condition the given condition.
    * @param message the message.
    */
-  public void warn(Condition condition, String message) {
+  public void warn(@NotNull Condition condition, @Nullable String message) {
     core().log(WARN, condition, message);
   }
 
@@ -424,7 +445,10 @@ public class Logger<FB extends Field.Builder> {
    * @param message the message.
    * @param f the field builder function.
    */
-  public void warn(Condition condition, String message, Field.BuilderFunction<FB> f) {
+  public void warn(
+      @NotNull Condition condition,
+      @Nullable String message,
+      @NotNull Field.BuilderFunction<FB> f) {
     core().log(WARN, condition, message, f, fieldBuilder);
   }
 
@@ -435,7 +459,7 @@ public class Logger<FB extends Field.Builder> {
    * @param message the message.
    * @param e the given exception.
    */
-  public void warn(Condition condition, String message, Throwable e) {
+  public void warn(@NotNull Condition condition, @Nullable String message, @NotNull Throwable e) {
     core().log(WARN, condition, message, e);
   }
 
@@ -451,7 +475,7 @@ public class Logger<FB extends Field.Builder> {
    * @param condition the given condition.
    * @return true if the logger level is ERROR or higher and the condition is met.
    */
-  public boolean isErrorEnabled(Condition condition) {
+  public boolean isErrorEnabled(@NotNull Condition condition) {
     return core().isEnabled(ERROR, condition);
   }
 
@@ -460,7 +484,7 @@ public class Logger<FB extends Field.Builder> {
    *
    * @param message the given message.
    */
-  public void error(String message) {
+  public void error(@Nullable String message) {
     core().log(ERROR, message);
   }
 
@@ -470,7 +494,7 @@ public class Logger<FB extends Field.Builder> {
    * @param message the message.
    * @param f the field builder function.
    */
-  public void error(String message, Field.BuilderFunction<FB> f) {
+  public void error(@Nullable String message, @NotNull Field.BuilderFunction<FB> f) {
     core().log(ERROR, message, f, fieldBuilder);
   }
 
@@ -480,7 +504,7 @@ public class Logger<FB extends Field.Builder> {
    * @param message the message.
    * @param e the given exception.
    */
-  public void error(String message, Throwable e) {
+  public void error(@Nullable String message, @NotNull Throwable e) {
     core().log(ERROR, message, e);
   }
 
@@ -490,7 +514,7 @@ public class Logger<FB extends Field.Builder> {
    * @param condition the given condition.
    * @param message the message.
    */
-  public void error(Condition condition, String message) {
+  public void error(@NotNull Condition condition, @Nullable String message) {
     core().log(ERROR, condition, message);
   }
 
@@ -501,7 +525,10 @@ public class Logger<FB extends Field.Builder> {
    * @param message the message.
    * @param f the field builder function.
    */
-  public void error(Condition condition, String message, Field.BuilderFunction<FB> f) {
+  public void error(
+      @NotNull Condition condition,
+      @Nullable String message,
+      @NotNull Field.BuilderFunction<FB> f) {
     core().log(ERROR, condition, message, f, fieldBuilder);
   }
 
@@ -512,7 +539,7 @@ public class Logger<FB extends Field.Builder> {
    * @param message the message.
    * @param e the given exception.
    */
-  public void error(Condition condition, String message, Throwable e) {
+  public void error(@NotNull Condition condition, @Nullable String message, @NotNull Throwable e) {
     core().log(ERROR, condition, message, e);
   }
 }

--- a/api/src/main/java/com/tersesystems/echopraxia/LoggerFactory.java
+++ b/api/src/main/java/com/tersesystems/echopraxia/LoggerFactory.java
@@ -3,6 +3,7 @@ package com.tersesystems.echopraxia;
 import com.tersesystems.echopraxia.core.Caller;
 import com.tersesystems.echopraxia.core.CoreLogger;
 import com.tersesystems.echopraxia.core.CoreLoggerFactory;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * The LoggerFactory class. This is used to create the appropriate `Logger`.
@@ -17,6 +18,7 @@ public class LoggerFactory {
    * @param clazz the logger class to use
    * @return the logger.
    */
+  @NotNull
   public static Logger<Field.Builder> getLogger(Class<?> clazz) {
     final CoreLogger core = CoreLoggerFactory.getLogger(clazz);
     return getLogger(core, Field.Builder.instance());
@@ -30,7 +32,9 @@ public class LoggerFactory {
    * @return the logger.
    * @param <FB> the type of field builder.
    */
-  public static <FB extends Field.Builder> Logger<FB> getLogger(Class<?> clazz, FB builder) {
+  @NotNull
+  public static <FB extends Field.Builder> Logger<FB> getLogger(
+      @NotNull Class<?> clazz, @NotNull FB builder) {
     CoreLogger coreLogger = LoggerFactory.getLogger(clazz).core();
     return getLogger(coreLogger, builder);
   }
@@ -41,7 +45,8 @@ public class LoggerFactory {
    * @param name the logger name to use
    * @return the logger.
    */
-  public static Logger<Field.Builder> getLogger(String name) {
+  @NotNull
+  public static Logger<Field.Builder> getLogger(@NotNull String name) {
     final CoreLogger core = CoreLoggerFactory.getLogger(name);
     return getLogger(core, Field.Builder.instance());
   }
@@ -54,7 +59,9 @@ public class LoggerFactory {
    * @param <FB> the type of field builder.
    * @return the logger.
    */
-  public static <FB extends Field.Builder> Logger<FB> getLogger(String name, FB builder) {
+  @NotNull
+  public static <FB extends Field.Builder> Logger<FB> getLogger(
+      @NotNull String name, @NotNull FB builder) {
     CoreLogger coreLogger = LoggerFactory.getLogger(name).core();
     return getLogger(coreLogger, builder);
   }
@@ -64,6 +71,7 @@ public class LoggerFactory {
    *
    * @return the logger.
    */
+  @NotNull
   public static Logger<Field.Builder> getLogger() {
     CoreLogger core = CoreLoggerFactory.getLogger(Caller.resolveClassName());
     return getLogger(core, Field.Builder.instance());
@@ -76,7 +84,8 @@ public class LoggerFactory {
    * @return the logger.
    * @param <FB> the type of field builder.
    */
-  public static <FB extends Field.Builder> Logger<FB> getLogger(FB fieldBuilder) {
+  @NotNull
+  public static <FB extends Field.Builder> Logger<FB> getLogger(@NotNull FB fieldBuilder) {
     CoreLogger core = CoreLoggerFactory.getLogger(Caller.resolveClassName());
     return getLogger(core, fieldBuilder);
   }
@@ -89,7 +98,9 @@ public class LoggerFactory {
    * @return the logger.
    * @param <FB> the type of field builder.
    */
-  public static <FB extends Field.Builder> Logger<FB> getLogger(CoreLogger core, FB fieldBuilder) {
+  @NotNull
+  public static <FB extends Field.Builder> Logger<FB> getLogger(
+      @NotNull CoreLogger core, @NotNull FB fieldBuilder) {
     return new Logger<>(core, fieldBuilder);
   }
 }

--- a/api/src/main/java/com/tersesystems/echopraxia/LoggingContext.java
+++ b/api/src/main/java/com/tersesystems/echopraxia/LoggingContext.java
@@ -1,6 +1,7 @@
 package com.tersesystems.echopraxia;
 
 import java.util.List;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * The LoggingContext interface is used in conditions to expose contextual information added to a
@@ -15,5 +16,6 @@ public interface LoggingContext {
    *
    * @return list of fields that are part of logger's context.
    */
+  @NotNull
   List<Field> getFields();
 }

--- a/api/src/main/java/com/tersesystems/echopraxia/ValueField.java
+++ b/api/src/main/java/com/tersesystems/echopraxia/ValueField.java
@@ -5,7 +5,7 @@ package com.tersesystems.echopraxia;
  *
  * <p>Indicates that the plain value should be rendered in message template.
  *
- * <p>This marker interface is used internally, but you typically won't need to use it directly.
- * You can call `Field.Builder.value` to get a instance of a field with this.
+ * <p>This marker interface is used internally, but you typically won't need to use it directly. You
+ * can call `Field.Builder.value` to get a instance of a field with this.
  */
 public interface ValueField extends Field {}

--- a/api/src/main/java/com/tersesystems/echopraxia/core/Caller.java
+++ b/api/src/main/java/com/tersesystems/echopraxia/core/Caller.java
@@ -1,7 +1,10 @@
 package com.tersesystems.echopraxia.core;
 
+import org.jetbrains.annotations.NotNull;
+
 public class Caller {
 
+  @NotNull
   public static String resolveClassName() {
     // If we're on JDK 9, we can use
     // StackWalker walker = StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE);
@@ -20,6 +23,6 @@ public class Caller {
         }
       }
     }
-    return null;
+    throw new IllegalStateException("No stack trace elements found in thread!");
   }
 }

--- a/api/src/main/java/com/tersesystems/echopraxia/core/CoreLogger.java
+++ b/api/src/main/java/com/tersesystems/echopraxia/core/CoreLogger.java
@@ -7,6 +7,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * The core logger API.
@@ -24,7 +26,7 @@ public interface CoreLogger {
    * @param level the level to log at.
    * @return true if the instance is enabled for the given level, false otherwise.
    */
-  boolean isEnabled(Level level);
+  boolean isEnabled(@NotNull Level level);
 
   /**
    * Is the logger instance enabled for the given level and conditions?
@@ -33,15 +35,15 @@ public interface CoreLogger {
    * @param condition the explicit condition that must be met.
    * @return true if the instance is enabled for the given level, false otherwise.
    */
-  boolean isEnabled(Level level, Condition condition);
+  boolean isEnabled(@NotNull Level level, @NotNull Condition condition);
 
   /**
    * Log a message at the given level.
    *
    * @param level the level to log at.
-   * @param message the message string to be logged
+   * @param message the message string to be logged, may be null.
    */
-  void log(Level level, String message);
+  void log(@NotNull Level level, @Nullable String message);
 
   /**
    * Log a message at the given level.
@@ -53,7 +55,10 @@ public interface CoreLogger {
    * @param <B> the type of field builder.
    */
   <B extends Field.Builder> void log(
-      Level level, String message, Field.BuilderFunction<B> f, B builder);
+      @NotNull Level level,
+      @Nullable String message,
+      @NotNull Field.BuilderFunction<B> f,
+      @NotNull B builder);
 
   /**
    * Log a message at the given level.
@@ -62,7 +67,7 @@ public interface CoreLogger {
    * @param message the message string to be logged
    * @param e the exception (throwable) to log
    */
-  void log(Level level, String message, Throwable e);
+  void log(@NotNull Level level, @Nullable String message, @NotNull Throwable e);
 
   /**
    * Log a message at the given level.
@@ -71,7 +76,7 @@ public interface CoreLogger {
    * @param condition the given condition
    * @param message the message string to be logged
    */
-  void log(Level level, Condition condition, String message);
+  void log(@NotNull Level level, @NotNull Condition condition, @Nullable String message);
 
   /**
    * Log a message at the given level.
@@ -81,7 +86,11 @@ public interface CoreLogger {
    * @param message the message string to be logged
    * @param e the exception (throwable) to log
    */
-  void log(Level level, Condition condition, String message, Throwable e);
+  void log(
+      @NotNull Level level,
+      @NotNull Condition condition,
+      @NotNull String message,
+      @NotNull Throwable e);
 
   /**
    * Log a message at the given level.
@@ -94,13 +103,18 @@ public interface CoreLogger {
    * @param <B> the type of field builder.
    */
   <B extends Field.Builder> void log(
-      Level level, Condition condition, String message, Field.BuilderFunction<B> f, B builder);
+      @NotNull Level level,
+      @NotNull Condition condition,
+      @Nullable String message,
+      @NotNull Field.BuilderFunction<B> f,
+      @NotNull B builder);
 
   /**
    * Returns the given condition
    *
    * @return the given condition.
    */
+  @NotNull
   Condition condition();
 
   /**
@@ -120,7 +134,9 @@ public interface CoreLogger {
    * @param <B> the type of field builder.
    * @return the core logger with given context fields applied.
    */
-  <B extends Field.Builder> CoreLogger withFields(Field.BuilderFunction<B> f, B builder);
+  @NotNull
+  <B extends Field.Builder> CoreLogger withFields(
+      @NotNull Field.BuilderFunction<B> f, @NotNull B builder);
 
   /**
    * Pulls fields from thread context into logger context, if any exist and the implementation
@@ -129,8 +145,9 @@ public interface CoreLogger {
    * @param mapTransform a function that takes a context map and returns a list of fields.
    * @return the core logger with any thread context mapped into fields.
    */
+  @NotNull
   CoreLogger withThreadContext(
-      Function<Supplier<Map<String, String>>, Supplier<List<Field>>> mapTransform);
+      @NotNull Function<Supplier<Map<String, String>>, Supplier<List<Field>>> mapTransform);
 
   /**
    * Adds the given condition to the logger.
@@ -138,5 +155,6 @@ public interface CoreLogger {
    * @param condition the given condition
    * @return the core logger with the condition applied.
    */
-  CoreLogger withCondition(Condition condition);
+  @NotNull
+  CoreLogger withCondition(@NotNull Condition condition);
 }

--- a/api/src/main/java/com/tersesystems/echopraxia/core/CoreLoggerFactory.java
+++ b/api/src/main/java/com/tersesystems/echopraxia/core/CoreLoggerFactory.java
@@ -3,6 +3,7 @@ package com.tersesystems.echopraxia.core;
 import java.util.Iterator;
 import java.util.ServiceConfigurationError;
 import java.util.ServiceLoader;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * The core logger factory.
@@ -11,14 +12,17 @@ import java.util.ServiceLoader;
  */
 public class CoreLoggerFactory {
 
-  public static CoreLogger getLogger(Class<?> clazz) {
+  @NotNull
+  public static CoreLogger getLogger(@NotNull Class<?> clazz) {
     return LazyHolder.INSTANCE.getLogger(clazz);
   }
 
-  public static CoreLogger getLogger(String name) {
+  @NotNull
+  public static CoreLogger getLogger(@NotNull String name) {
     return LazyHolder.INSTANCE.getLogger(name);
   }
 
+  @NotNull
   public static CoreLogger getLogger() {
     return getLogger(Caller.resolveClassName());
   }

--- a/api/src/main/java/com/tersesystems/echopraxia/core/CoreLoggerProvider.java
+++ b/api/src/main/java/com/tersesystems/echopraxia/core/CoreLoggerProvider.java
@@ -1,5 +1,7 @@
 package com.tersesystems.echopraxia.core;
 
+import org.jetbrains.annotations.NotNull;
+
 /**
  * The CoreLoggerProvider is a service provider interface used by LoggerFactory.
  *
@@ -7,7 +9,9 @@ package com.tersesystems.echopraxia.core;
  */
 public interface CoreLoggerProvider {
 
-  CoreLogger getLogger(Class<?> clazz);
+  @NotNull
+  CoreLogger getLogger(@NotNull Class<?> clazz);
 
-  CoreLogger getLogger(String name);
+  @NotNull
+  CoreLogger getLogger(@NotNull String name);
 }

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ spotless {
 }
 
 subprojects { subproj ->
-    apply plugin: 'java'
+    apply plugin: 'java-library'
     apply plugin: 'com.diffplug.spotless'
 
     repositories {
@@ -61,9 +61,8 @@ subprojects { subproj ->
     }
 
     dependencies {
-        // https://mvnrepository.com/artifact/org.jetbrains/annotations
-        // https://github.com/JetBrains/java-annotations#using-the-annotations
-        compileOnly 'org.jetbrains:annotations:23.0.0'
+        // https://docs.gradle.org/6.7.1/release-notes.html
+        compileOnlyApi 'org.jetbrains:annotations:23.0.0'
 
         // Fix a dependency in log4jbenchmarks
         jmhImplementation 'org.jetbrains:annotations:23.0.0'

--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,13 @@ subprojects { subproj ->
     }
 
     dependencies {
+        // https://mvnrepository.com/artifact/org.jetbrains/annotations
+        // https://github.com/JetBrains/java-annotations#using-the-annotations
+        compileOnly 'org.jetbrains:annotations:23.0.0'
+
+        // Fix a dependency in log4jbenchmarks
+        jmhImplementation 'org.jetbrains:annotations:23.0.0'
+
         jmhImplementation 'org.openjdk.jmh:jmh-core:1.34'
         jmhAnnotationProcessor 'org.openjdk.jmh:jmh-generator-annprocess:1.34'
 

--- a/fluent/src/main/java/com/tersesystems/echopraxia/fluent/FluentLogger.java
+++ b/fluent/src/main/java/com/tersesystems/echopraxia/fluent/FluentLogger.java
@@ -11,6 +11,8 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * FluentLogger class.
@@ -27,29 +29,36 @@ public class FluentLogger<FB extends Field.Builder> {
     this.builder = builder;
   }
 
+  @NotNull
   public CoreLogger core() {
     return core;
   }
 
+  @NotNull
   public FB fieldBuilder() {
     return builder;
   }
 
-  public FluentLogger<FB> withCondition(Condition c) {
+  @NotNull
+  public FluentLogger<FB> withCondition(@NotNull Condition c) {
     CoreLogger coreLogger = core.withCondition(c);
     return new FluentLogger<>(coreLogger, builder);
   }
 
-  public FluentLogger<FB> withFields(Field.BuilderFunction<FB> f) {
+  @NotNull
+  public FluentLogger<FB> withFields(@NotNull Field.BuilderFunction<FB> f) {
     CoreLogger coreLogger = core.withFields(f, builder);
     return new FluentLogger<>(coreLogger, builder);
   }
 
-  public <T extends Field.Builder> FluentLogger<T> withFieldBuilder(T newBuilder) {
+  @NotNull
+  public <T extends Field.Builder> FluentLogger<T> withFieldBuilder(@NotNull T newBuilder) {
     return new FluentLogger<>(core, newBuilder);
   }
 
-  public <T extends Field.Builder> FluentLogger<T> withFieldBuilder(Class<T> newBuilderClass) {
+  @NotNull
+  public <T extends Field.Builder> FluentLogger<T> withFieldBuilder(
+      @NotNull Class<T> newBuilderClass) {
     try {
       final T newInstance = newBuilderClass.getDeclaredConstructor().newInstance();
       return new FluentLogger<>(core, newInstance);
@@ -62,6 +71,7 @@ public class FluentLogger<FB extends Field.Builder> {
     }
   }
 
+  @NotNull
   public FluentLogger<FB> withThreadContext() {
     Function<Supplier<Map<String, String>>, Supplier<List<Field>>> mapTransform =
         mapSupplier ->
@@ -121,26 +131,32 @@ public class FluentLogger<FB extends Field.Builder> {
     return core.isEnabled(level, condition);
   }
 
+  @NotNull
   public EntryBuilder atError() {
     return atLevel(Level.ERROR);
   }
 
+  @NotNull
   public EntryBuilder atWarn() {
     return atLevel(Level.WARN);
   }
 
+  @NotNull
   public EntryBuilder atInfo() {
     return atLevel(Level.INFO);
   }
 
+  @NotNull
   public EntryBuilder atDebug() {
     return atLevel(Level.DEBUG);
   }
 
+  @NotNull
   public EntryBuilder atTrace() {
     return atLevel(Level.TRACE);
   }
 
+  @NotNull
   public EntryBuilder atLevel(Level level) {
     return new EntryBuilder(level);
   }
@@ -155,22 +171,26 @@ public class FluentLogger<FB extends Field.Builder> {
       this.level = level;
     }
 
-    public EntryBuilder condition(Condition condition) {
+    @NotNull
+    public EntryBuilder condition(@NotNull Condition condition) {
       this.condition = this.condition.and(condition);
       return this;
     }
 
-    public EntryBuilder message(String message) {
+    @NotNull
+    public EntryBuilder message(@Nullable String message) {
       this.message = message;
       return this;
     }
 
-    public EntryBuilder argument(Function<FB, Field> f) {
+    @NotNull
+    public EntryBuilder argument(@NotNull Function<FB, Field> f) {
       this.argumentFnList.add(f);
       return this;
     }
 
-    public EntryBuilder exception(Throwable t) {
+    @NotNull
+    public EntryBuilder exception(@NotNull Throwable t) {
       return argument(b -> b.exception(t));
     }
 

--- a/log4j/src/jmh/java/com/tersesystems/echopraxia/log4j/Log4JBenchmarks.java
+++ b/log4j/src/jmh/java/com/tersesystems/echopraxia/log4j/Log4JBenchmarks.java
@@ -13,6 +13,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.message.Message;
+import org.jetbrains.annotations.NotNull;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.infra.Blackhole;
 
@@ -74,12 +75,12 @@ public class Log4JBenchmarks {
     }
 
     @Override
-    public String name() {
+    public @NotNull String name() {
       return name;
     }
 
     @Override
-    public Value<?> value() {
+    public @NotNull Value<?> value() {
       return value;
     }
   }

--- a/log4j/src/main/java/com/tersesystems/echopraxia/log4j/Log4JCoreLogger.java
+++ b/log4j/src/main/java/com/tersesystems/echopraxia/log4j/Log4JCoreLogger.java
@@ -16,6 +16,8 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.ThreadContext;
 import org.apache.logging.log4j.message.Message;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /** A core logger using the Log4J API. */
 public class Log4JCoreLogger implements CoreLogger {
@@ -37,7 +39,7 @@ public class Log4JCoreLogger implements CoreLogger {
   }
 
   @Override
-  public boolean isEnabled(Level level) {
+  public boolean isEnabled(@NotNull Level level) {
     if (this.condition == Condition.never()) {
       return false;
     }
@@ -58,7 +60,7 @@ public class Log4JCoreLogger implements CoreLogger {
   }
 
   @Override
-  public boolean isEnabled(Level level, Condition condition) {
+  public boolean isEnabled(@NotNull Level level, @NotNull Condition condition) {
     if (condition == Condition.always()) {
       return isEnabled(level);
     }
@@ -82,7 +84,7 @@ public class Log4JCoreLogger implements CoreLogger {
   }
 
   @Override
-  public void log(Level level, String message) {
+  public void log(@NotNull Level level, String message) {
     if (!condition.test(level, context)) {
       return;
     }
@@ -91,17 +93,21 @@ public class Log4JCoreLogger implements CoreLogger {
 
   @Override
   public <B extends Field.Builder> void log(
-      Level level, String message, Field.BuilderFunction<B> f, B builder) {
+      @NotNull Level level,
+      @Nullable String messageTemplate,
+      @NotNull Field.BuilderFunction<B> f,
+      @NotNull B builder) {
     if (!condition.test(level, context)) {
       return;
     }
-    List<Field> argumentFields = f.apply(builder);
-    Throwable e = findThrowable(argumentFields);
-    logger.log(convertLevel(level), context.getMarker(), createMessage(message, argumentFields), e);
+    final List<Field> argumentFields = f.apply(builder);
+    final Throwable e = findThrowable(argumentFields);
+    final Message message = createMessage(messageTemplate, argumentFields);
+    logger.log(convertLevel(level), context.getMarker(), message, e);
   }
 
   @Override
-  public void log(Level level, String message, Throwable e) {
+  public void log(@NotNull Level level, String message, @NotNull Throwable e) {
     if (!condition.test(level, context)) {
       return;
     }
@@ -113,7 +119,7 @@ public class Log4JCoreLogger implements CoreLogger {
   }
 
   @Override
-  public void log(Level level, Condition condition, String message) {
+  public void log(@NotNull Level level, @NotNull Condition condition, @Nullable String message) {
     if (!condition.test(level, context)) {
       return;
     }
@@ -121,7 +127,11 @@ public class Log4JCoreLogger implements CoreLogger {
   }
 
   @Override
-  public void log(Level level, Condition condition, String message, Throwable e) {
+  public void log(
+      @NotNull Level level,
+      @NotNull Condition condition,
+      @NotNull String message,
+      @NotNull Throwable e) {
     if (!condition.test(level, context)) {
       return;
     }
@@ -130,7 +140,11 @@ public class Log4JCoreLogger implements CoreLogger {
 
   @Override
   public <B extends Field.Builder> void log(
-      Level level, Condition condition, String message, Field.BuilderFunction<B> f, B builder) {
+      @NotNull Level level,
+      @NotNull Condition condition,
+      String message,
+      Field.@NotNull BuilderFunction<B> f,
+      @NotNull B builder) {
     if (!condition.test(level, context)) {
       return;
     }
@@ -138,26 +152,27 @@ public class Log4JCoreLogger implements CoreLogger {
   }
 
   @Override
-  public Condition condition() {
+  public @NotNull Condition condition() {
     return this.condition;
   }
 
   @Override
-  public <B extends Field.Builder> CoreLogger withFields(Field.BuilderFunction<B> f, B builder) {
+  public <B extends Field.Builder> @NotNull CoreLogger withFields(
+      Field.@NotNull BuilderFunction<B> f, @NotNull B builder) {
     Log4JLoggingContext newContext = new Log4JLoggingContext(() -> f.apply(builder), null);
     return new Log4JCoreLogger(logger, context.and(newContext), condition);
   }
 
   @Override
-  public CoreLogger withThreadContext(
-      Function<Supplier<Map<String, String>>, Supplier<List<Field>>> mapTransform) {
+  public @NotNull CoreLogger withThreadContext(
+      @NotNull Function<Supplier<Map<String, String>>, Supplier<List<Field>>> mapTransform) {
     Supplier<List<Field>> fieldSupplier = mapTransform.apply(ThreadContext::getImmutableContext);
     Log4JLoggingContext newContext = new Log4JLoggingContext(fieldSupplier, null);
     return new Log4JCoreLogger(logger, this.context.and(newContext), condition);
   }
 
   @Override
-  public CoreLogger withCondition(Condition condition) {
+  public @NotNull CoreLogger withCondition(@NotNull Condition condition) {
     if (condition == Condition.never()) {
       if (this.condition == Condition.never()) {
         return this;

--- a/log4j/src/main/java/com/tersesystems/echopraxia/log4j/Log4JCoreLoggerProvider.java
+++ b/log4j/src/main/java/com/tersesystems/echopraxia/log4j/Log4JCoreLoggerProvider.java
@@ -5,16 +5,17 @@ import com.tersesystems.echopraxia.core.CoreLogger;
 import com.tersesystems.echopraxia.core.CoreLoggerProvider;
 import java.util.Collections;
 import org.apache.logging.log4j.LogManager;
+import org.jetbrains.annotations.NotNull;
 
 public class Log4JCoreLoggerProvider implements CoreLoggerProvider {
 
   @Override
-  public CoreLogger getLogger(Class<?> clazz) {
+  public @NotNull CoreLogger getLogger(@NotNull Class<?> clazz) {
     return getLogger(clazz.getName());
   }
 
   @Override
-  public CoreLogger getLogger(String name) {
+  public @NotNull CoreLogger getLogger(@NotNull String name) {
     org.apache.logging.log4j.Logger log4jLogger = LogManager.getLogger(name);
     Log4JLoggingContext context = new Log4JLoggingContext(Collections::emptyList, null);
     Condition condition = Condition.always();

--- a/log4j/src/main/java/com/tersesystems/echopraxia/log4j/Log4JLoggingContext.java
+++ b/log4j/src/main/java/com/tersesystems/echopraxia/log4j/Log4JLoggingContext.java
@@ -8,6 +8,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.logging.log4j.Marker;
+import org.jetbrains.annotations.NotNull;
 
 public class Log4JLoggingContext implements LoggingContext {
 
@@ -25,7 +26,7 @@ public class Log4JLoggingContext implements LoggingContext {
   }
 
   @Override
-  public List<Field> getFields() {
+  public @NotNull List<Field> getFields() {
     return fieldsSupplier.get();
   }
 

--- a/log4j/src/main/java/com/tersesystems/echopraxia/log4j/layout/EchopraxiaFieldSerializer.java
+++ b/log4j/src/main/java/com/tersesystems/echopraxia/log4j/layout/EchopraxiaFieldSerializer.java
@@ -14,48 +14,57 @@ import javax.json.JsonValue;
 class EchopraxiaFieldSerializer {
 
   void convertField(JsonObjectBuilder builder, Field f) {
-    switch (f.value().type()) {
+    final String name = f.name();
+    final Value<?> v = f.value();
+
+    // if raw() is null and it's not NullValue, then chalk up an error and keep going.
+    if (v.type() == Value.ValueType.NULL || v.raw() == null) {
+      builder.addNull(name);
+      return;
+    }
+
+    switch (v.type()) {
       case ARRAY:
         final JsonArrayBuilder arrayBuilder = Json.createArrayBuilder();
         //noinspection unchecked
-        final List<Value<?>> arrayValues = (List<Value<?>>) f.value().raw();
+        final List<Value<?>> arrayValues = (List<Value<?>>) v.raw();
         for (Value<?> value : arrayValues) {
           addValue(value, arrayBuilder);
         }
-        builder.add(f.name(), arrayBuilder);
+        builder.add(name, arrayBuilder);
         break;
       case OBJECT:
         final JsonObjectBuilder objectBuilder = Json.createObjectBuilder();
         //noinspection unchecked
-        final List<Field> fields = (List<Field>) f.value().raw();
+        final List<Field> fields = (List<Field>) v.raw();
         addObject(fields, objectBuilder);
-        builder.add(f.name(), objectBuilder);
+        builder.add(name, objectBuilder);
         break;
       case STRING:
-        builder.add(f.name(), (String) f.value().raw());
+        builder.add(name, (String) v.raw());
         break;
       case NUMBER:
-        final Object raw = f.value().raw();
+        final Object raw = v.raw();
         if (raw instanceof Integer) {
-          builder.add(f.name(), (Integer) raw);
+          builder.add(name, (Integer) raw);
         } else if (raw instanceof Long) {
-          builder.add(f.name(), (Long) raw);
+          builder.add(name, (Long) raw);
         } else if (raw instanceof Double) {
-          builder.add(f.name(), (Double) raw);
+          builder.add(name, (Double) raw);
         } else if (raw instanceof BigDecimal) {
-          builder.add(f.name(), (BigDecimal) raw);
+          builder.add(name, (BigDecimal) raw);
         } else if (raw instanceof BigInteger) {
-          builder.add(f.name(), (BigInteger) raw);
+          builder.add(name, (BigInteger) raw);
         }
         break;
       case BOOLEAN:
-        builder.add(f.name(), (Boolean) f.value().raw());
+        builder.add(name, (Boolean) v.raw());
         break;
       case EXCEPTION:
         // do nothing for right now...
         break;
       case NULL:
-        builder.addNull(f.name());
+        builder.addNull(name); // should never be reached, but okay :-)
         break;
     }
   }

--- a/log4j/src/main/java/com/tersesystems/echopraxia/log4j/layout/EchopraxiaFieldSerializer.java
+++ b/log4j/src/main/java/com/tersesystems/echopraxia/log4j/layout/EchopraxiaFieldSerializer.java
@@ -70,6 +70,7 @@ class EchopraxiaFieldSerializer {
   }
 
   private void addValue(Value<?> value, JsonArrayBuilder arrayBuilder) {
+    final Object rawValue = value.raw();
     switch (value.type()) {
       case ARRAY:
         JsonArrayBuilder newArrayBuilder = Json.createArrayBuilder();
@@ -79,29 +80,38 @@ class EchopraxiaFieldSerializer {
       case OBJECT:
         final JsonObjectBuilder objectBuilder = Json.createObjectBuilder();
         //noinspection unchecked
-        List<Field> valueFields = (List<Field>) value.raw();
+        List<Field> valueFields = (List<Field>) rawValue;
         addObject(valueFields, objectBuilder);
         arrayBuilder.add(objectBuilder);
         break;
       case STRING:
-        arrayBuilder.add((String) value.raw());
+        if (rawValue == null) {
+          arrayBuilder.add(JsonValue.NULL);
+        } else {
+          arrayBuilder.add((String) rawValue);
+        }
         break;
       case NUMBER:
-        final Object raw = value.raw();
-        if (raw instanceof Integer) {
-          arrayBuilder.add((Integer) raw);
-        } else if (raw instanceof Long) {
-          arrayBuilder.add((Long) raw);
-        } else if (raw instanceof Double) {
-          arrayBuilder.add((Double) raw);
-        } else if (raw instanceof BigDecimal) {
-          arrayBuilder.add((BigDecimal) raw);
-        } else if (raw instanceof BigInteger) {
-          arrayBuilder.add((BigInteger) raw);
+        if (rawValue instanceof Integer) {
+          arrayBuilder.add((Integer) rawValue);
+        } else if (rawValue instanceof Long) {
+          arrayBuilder.add((Long) rawValue);
+        } else if (rawValue instanceof Double) {
+          arrayBuilder.add((Double) rawValue);
+        } else if (rawValue instanceof BigDecimal) {
+          arrayBuilder.add((BigDecimal) rawValue);
+        } else if (rawValue instanceof BigInteger) {
+          arrayBuilder.add((BigInteger) rawValue);
+        } else {
+          arrayBuilder.add(JsonValue.NULL);
         }
         break;
       case BOOLEAN:
-        arrayBuilder.add((Boolean) value.raw());
+        if (rawValue == null) {
+          arrayBuilder.add(JsonValue.NULL);
+        } else {
+          arrayBuilder.add((Boolean) rawValue);
+        }
         break;
       case EXCEPTION:
         // Do nothing for now...

--- a/log4j/src/test/java/com/tersesystems/echopraxia/log4j/LoggerTest.java
+++ b/log4j/src/test/java/com/tersesystems/echopraxia/log4j/LoggerTest.java
@@ -1,6 +1,7 @@
 package com.tersesystems.echopraxia.log4j;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import com.tersesystems.echopraxia.Field;
 import com.tersesystems.echopraxia.Logger;
@@ -14,6 +15,44 @@ import javax.json.JsonValue;
 import org.junit.jupiter.api.Test;
 
 public class LoggerTest extends TestBase {
+
+  @Test
+  void testNullStringArgument() {
+    Logger<?> logger = getLogger();
+    String value = null;
+    logger.info("hello {}", fb -> fb.only(fb.string("name", value)));
+
+    JsonObject entry = getEntry();
+    final String message = entry.getString("message");
+    assertThat(message).isEqualTo("hello null");
+  }
+
+  @Test
+  void testNullFieldName() {
+    Logger<?> logger = getLogger();
+    String value = "value";
+    logger.debug("hello {}", fb -> fb.only(fb.string(null, value)));
+
+    JsonObject entry = getEntry();
+    final String message = entry.getString("message");
+    assertThat(message).isEqualTo("my argument is random_object={value1, value2}");
+  }
+
+  @Test
+  void testNullArrayElement() {
+    fail();
+  }
+
+  @Test
+  void testNullNumber() {
+    Logger<?> logger = getLogger();
+    Number value = null;
+    logger.debug("hello {}", fb -> fb.only(fb.number("name", value)));
+
+    JsonObject entry = getEntry();
+    final String message = entry.getString("message");
+    assertThat(message).isEqualTo("my argument is random_object={value1, value2}");
+  }
 
   @Test
   public void testLoggerWithStringField() {

--- a/log4j/src/test/java/com/tersesystems/echopraxia/log4j/LoggerTest.java
+++ b/log4j/src/test/java/com/tersesystems/echopraxia/log4j/LoggerTest.java
@@ -38,17 +38,6 @@ public class LoggerTest extends TestBase {
   }
 
   @Test
-  void testNullArrayElement() {
-    Logger<?> logger = getLogger();
-    String[] values = {"1", null, "3"};
-    logger.debug("array field is {}", fb -> fb.only(fb.array("arrayName", values)));
-
-    JsonObject entry = getEntry();
-    final String message = entry.getString("message");
-    assertThat(message).isEqualTo("array field is arrayName=[1, null, 3]");
-  }
-
-  @Test
   void testNullNumber() {
     Logger<?> logger = getLogger();
     Number value = null;
@@ -67,6 +56,17 @@ public class LoggerTest extends TestBase {
     JsonObject entry = getEntry();
     final String message = entry.getString("message");
     assertThat(message).isEqualTo("boolean is null");
+  }
+
+  @Test
+  void testNullArrayElement() {
+    Logger<?> logger = getLogger();
+    String[] values = {"1", null, "3"};
+    logger.debug("array field is {}", fb -> fb.only(fb.array("arrayName", values)));
+
+    JsonObject entry = getEntry();
+    final String message = entry.getString("message");
+    assertThat(message).isEqualTo("array field is arrayName=[1, null, 3]");
   }
 
   @Test

--- a/log4j/src/test/java/com/tersesystems/echopraxia/log4j/LoggerTest.java
+++ b/log4j/src/test/java/com/tersesystems/echopraxia/log4j/LoggerTest.java
@@ -1,7 +1,6 @@
 package com.tersesystems.echopraxia.log4j;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import com.tersesystems.echopraxia.Field;
 import com.tersesystems.echopraxia.Logger;
@@ -31,27 +30,55 @@ public class LoggerTest extends TestBase {
   void testNullFieldName() {
     Logger<?> logger = getLogger();
     String value = "value";
-    logger.debug("hello {}", fb -> fb.only(fb.string(null, value)));
+    logger.debug("array field is {}", fb -> fb.only(fb.array(null, value)));
 
     JsonObject entry = getEntry();
     final String message = entry.getString("message");
-    assertThat(message).isEqualTo("my argument is random_object={value1, value2}");
+    assertThat(message).isEqualTo("array field is echopraxia-unknown-1=[value]");
   }
 
   @Test
   void testNullArrayElement() {
-    fail();
+    Logger<?> logger = getLogger();
+    String[] values = {"1", null, "3"};
+    logger.debug("array field is {}", fb -> fb.only(fb.array("arrayName", values)));
+
+    JsonObject entry = getEntry();
+    final String message = entry.getString("message");
+    assertThat(message).isEqualTo("array field is arrayName=[1, null, 3]");
   }
 
   @Test
   void testNullNumber() {
     Logger<?> logger = getLogger();
     Number value = null;
-    logger.debug("hello {}", fb -> fb.only(fb.number("name", value)));
+    logger.debug("number is {}", fb -> fb.only(fb.number("name", value)));
 
     JsonObject entry = getEntry();
     final String message = entry.getString("message");
-    assertThat(message).isEqualTo("my argument is random_object={value1, value2}");
+    assertThat(message).isEqualTo("number is null");
+  }
+
+  @Test
+  void testNullBoolean() {
+    Logger<?> logger = getLogger();
+    logger.debug("boolean is {}", fb -> fb.only(fb.bool("name", (Boolean) null)));
+
+    JsonObject entry = getEntry();
+    final String message = entry.getString("message");
+    assertThat(message).isEqualTo("boolean is null");
+  }
+
+  @Test
+  void testNullObject() {
+    Logger<?> logger = getLogger();
+    logger.debug(
+        "object is {}", fb -> fb.only(fb.object("name", Field.Value.object((Field) null))));
+
+    JsonObject entry = getEntry();
+    final String message = entry.getString("message");
+    assertThat(message)
+        .isEqualTo("object is name={}"); // {} here is literally an object with no fields
   }
 
   @Test

--- a/log4j/src/test/resources/log4j2.xml
+++ b/log4j/src/test/resources/log4j2.xml
@@ -47,7 +47,7 @@
         </List>
     </Appenders>
     <Loggers>
-        <Root level="info">
+        <Root level="trace">
             <AppenderRef ref="Console"/>
             <AppenderRef ref="ListAppender"/>
         </Root>

--- a/log4j/src/test/resources/log4j2.xml
+++ b/log4j/src/test/resources/log4j2.xml
@@ -47,7 +47,7 @@
         </List>
     </Appenders>
     <Loggers>
-        <Root level="trace">
+        <Root level="debug">
             <AppenderRef ref="Console"/>
             <AppenderRef ref="ListAppender"/>
         </Root>

--- a/logstash/src/main/java/com/tersesystems/echopraxia/logstash/LogstashCoreLogger.java
+++ b/logstash/src/main/java/com/tersesystems/echopraxia/logstash/LogstashCoreLogger.java
@@ -14,6 +14,7 @@ import java.util.stream.Collectors;
 import net.logstash.logback.argument.StructuredArgument;
 import net.logstash.logback.argument.StructuredArguments;
 import net.logstash.logback.marker.Markers;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.MDC;
 import org.slf4j.Marker;
 
@@ -52,20 +53,21 @@ public class LogstashCoreLogger implements CoreLogger {
    * @return the condition.
    */
   @Override
-  public Condition condition() {
+  public @NotNull Condition condition() {
     return this.condition;
   }
 
   @Override
-  public <B extends Field.Builder> CoreLogger withFields(Field.BuilderFunction<B> f, B builder) {
+  public <B extends Field.Builder> @NotNull CoreLogger withFields(
+      Field.@NotNull BuilderFunction<B> f, @NotNull B builder) {
     LogstashLoggingContext newContext =
         new LogstashLoggingContext(() -> f.apply(builder), Collections::emptyList);
     return new LogstashCoreLogger(logger, this.context.and(newContext), condition);
   }
 
   @Override
-  public CoreLogger withThreadContext(
-      Function<Supplier<Map<String, String>>, Supplier<List<Field>>> mapTransform) {
+  public @NotNull CoreLogger withThreadContext(
+      @NotNull Function<Supplier<Map<String, String>>, Supplier<List<Field>>> mapTransform) {
     Supplier<List<Field>> fieldSupplier = mapTransform.apply(MDC::getCopyOfContextMap);
     LogstashLoggingContext newContext =
         new LogstashLoggingContext(fieldSupplier, Collections::emptyList);
@@ -73,7 +75,7 @@ public class LogstashCoreLogger implements CoreLogger {
   }
 
   @Override
-  public CoreLogger withCondition(Condition condition) {
+  public @NotNull CoreLogger withCondition(@NotNull Condition condition) {
     if (condition == Condition.always()) {
       return this;
     }
@@ -93,7 +95,7 @@ public class LogstashCoreLogger implements CoreLogger {
   }
 
   @Override
-  public boolean isEnabled(Level level) {
+  public boolean isEnabled(@NotNull Level level) {
     if (condition == Condition.never()) {
       return false;
     }
@@ -114,7 +116,7 @@ public class LogstashCoreLogger implements CoreLogger {
   }
 
   @Override
-  public boolean isEnabled(Level level, Condition condition) {
+  public boolean isEnabled(@NotNull Level level, @NotNull Condition condition) {
     if (condition == Condition.always()) {
       return isEnabled(level);
     }
@@ -138,7 +140,7 @@ public class LogstashCoreLogger implements CoreLogger {
   }
 
   @Override
-  public void log(Level level, String message) {
+  public void log(@NotNull Level level, String message) {
     if (!condition.test(level, context)) {
       return;
     }
@@ -165,7 +167,10 @@ public class LogstashCoreLogger implements CoreLogger {
 
   @Override
   public <FB extends Field.Builder> void log(
-      Level level, String message, Field.BuilderFunction<FB> f, FB builder) {
+      @NotNull Level level,
+      String message,
+      Field.@NotNull BuilderFunction<FB> f,
+      @NotNull FB builder) {
     if (!condition.test(level, context)) {
       return;
     }
@@ -211,7 +216,7 @@ public class LogstashCoreLogger implements CoreLogger {
   }
 
   @Override
-  public void log(Level level, String message, Throwable e) {
+  public void log(@NotNull Level level, String message, @NotNull Throwable e) {
     if (!condition.test(level, context)) {
       return;
     }
@@ -237,7 +242,7 @@ public class LogstashCoreLogger implements CoreLogger {
   }
 
   @Override
-  public void log(Level level, Condition condition, String message) {
+  public void log(@NotNull Level level, @NotNull Condition condition, String message) {
     if (!condition.test(level, context)) {
       return;
     }
@@ -245,7 +250,11 @@ public class LogstashCoreLogger implements CoreLogger {
   }
 
   @Override
-  public void log(Level level, Condition condition, String message, Throwable e) {
+  public void log(
+      @NotNull Level level,
+      @NotNull Condition condition,
+      @NotNull String message,
+      @NotNull Throwable e) {
     if (!condition.test(level, context)) {
       return;
     }
@@ -254,7 +263,11 @@ public class LogstashCoreLogger implements CoreLogger {
 
   @Override
   public <B extends Field.Builder> void log(
-      Level level, Condition condition, String message, Field.BuilderFunction<B> f, B builder) {
+      @NotNull Level level,
+      @NotNull Condition condition,
+      String message,
+      Field.@NotNull BuilderFunction<B> f,
+      @NotNull B builder) {
     if (!condition.test(level, context)) {
       return;
     }

--- a/logstash/src/main/java/com/tersesystems/echopraxia/logstash/LogstashLoggerProvider.java
+++ b/logstash/src/main/java/com/tersesystems/echopraxia/logstash/LogstashLoggerProvider.java
@@ -2,6 +2,7 @@ package com.tersesystems.echopraxia.logstash;
 
 import com.tersesystems.echopraxia.core.CoreLogger;
 import com.tersesystems.echopraxia.core.CoreLoggerProvider;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.ILoggerFactory;
 
 /**
@@ -11,11 +12,11 @@ import org.slf4j.ILoggerFactory;
  */
 public class LogstashLoggerProvider implements CoreLoggerProvider {
 
-  public CoreLogger getLogger(Class<?> clazz) {
+  public @NotNull CoreLogger getLogger(@NotNull Class<?> clazz) {
     return getLogger(clazz.getName());
   }
 
-  public CoreLogger getLogger(String name) {
+  public @NotNull CoreLogger getLogger(@NotNull String name) {
     ILoggerFactory factory = org.slf4j.LoggerFactory.getILoggerFactory();
     org.slf4j.Logger logger = factory.getLogger(name);
     return new LogstashCoreLogger(logger);

--- a/logstash/src/main/java/com/tersesystems/echopraxia/logstash/LogstashLoggingContext.java
+++ b/logstash/src/main/java/com/tersesystems/echopraxia/logstash/LogstashLoggingContext.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.jetbrains.annotations.NotNull;
 import org.slf4j.Marker;
 
 /**
@@ -33,7 +34,7 @@ public class LogstashLoggingContext implements LoggingContext {
   }
 
   @Override
-  public List<Field> getFields() {
+  public @NotNull List<Field> getFields() {
     return fieldsSupplier.get();
   }
 

--- a/logstash/src/main/java/com/tersesystems/echopraxia/logstash/jackson/FieldSerializer.java
+++ b/logstash/src/main/java/com/tersesystems/echopraxia/logstash/jackson/FieldSerializer.java
@@ -27,11 +27,12 @@ public class FieldSerializer extends StdSerializer<Field> {
   @Override
   public void serialize(Field field, JsonGenerator jgen, SerializerProvider provider)
       throws IOException {
-    Value<?> value = field.value();
+    final Value<?> value = field.value();
+    final String name = field.name();
     switch (value.type()) {
       case ARRAY:
         List<Value<?>> arrayValues = ((Value.ArrayValue) value).raw();
-        jgen.writeArrayFieldStart(field.name());
+        jgen.writeArrayFieldStart(name);
         for (Value<?> av : arrayValues) {
           jgen.writeObject(av);
         }
@@ -39,41 +40,41 @@ public class FieldSerializer extends StdSerializer<Field> {
         break;
       case OBJECT:
         List<Field> objFields = ((Value.ObjectValue) value).raw();
-        jgen.writeObjectFieldStart(field.name());
+        jgen.writeObjectFieldStart(name);
         for (Field objField : objFields) {
           jgen.writeObject(objField);
         }
         jgen.writeEndObject();
         break;
       case STRING:
-        jgen.writeStringField(field.name(), value.raw().toString());
+        jgen.writeStringField(name, value.raw().toString());
         break;
       case NUMBER:
         Number n = ((Value.NumberValue) value).raw();
         if (n instanceof Byte) {
-          jgen.writeNumberField(field.name(), n.byteValue());
+          jgen.writeNumberField(name, n.byteValue());
         } else if (n instanceof Short) {
-          jgen.writeNumberField(field.name(), n.shortValue());
+          jgen.writeNumberField(name, n.shortValue());
         } else if (n instanceof Integer) {
-          jgen.writeNumberField(field.name(), n.intValue());
+          jgen.writeNumberField(name, n.intValue());
         } else if (n instanceof Long) {
-          jgen.writeNumberField(field.name(), n.longValue());
+          jgen.writeNumberField(name, n.longValue());
         } else if (n instanceof Double) {
-          jgen.writeNumberField(field.name(), n.doubleValue());
+          jgen.writeNumberField(name, n.doubleValue());
         } else if (n instanceof BigInteger) {
-          jgen.writeNumberField(field.name(), (BigInteger) n);
+          jgen.writeNumberField(name, (BigInteger) n);
         } else if (n instanceof BigDecimal) {
-          jgen.writeNumberField(field.name(), (BigDecimal) n);
+          jgen.writeNumberField(name, (BigDecimal) n);
         }
         break;
       case BOOLEAN:
         boolean b = ((Value.BooleanValue) value).raw();
-        jgen.writeBooleanField(field.name(), b);
+        jgen.writeBooleanField(name, b);
         break;
       case EXCEPTION:
         break;
       case NULL:
-        jgen.writeNullField(field.name());
+        jgen.writeNullField(name);
         break;
     }
   }

--- a/logstash/src/test/java/com/tersesystems/echopraxia/logstash/LoggerTest.java
+++ b/logstash/src/test/java/com/tersesystems/echopraxia/logstash/LoggerTest.java
@@ -36,6 +36,17 @@ class LoggerTest extends TestBase {
   }
 
   @Test
+  void testNullMessage() {
+    Logger<?> logger = getLogger();
+    logger.debug(null);
+
+    final ListAppender<ILoggingEvent> listAppender = getListAppender();
+    final ILoggingEvent event = listAppender.list.get(0);
+    final String formattedMessage = event.getFormattedMessage();
+    assertThat(formattedMessage).isEqualTo(null);
+  }
+
+  @Test
   void testArguments() {
     Logger<?> logger = getLogger();
     logger.debug(
@@ -46,12 +57,6 @@ class LoggerTest extends TestBase {
     final ILoggingEvent event = listAppender.list.get(0);
     final String formattedMessage = event.getFormattedMessage();
     assertThat(formattedMessage).isEqualTo("hello will, you are 13, citizen status true");
-  }
-
-  private Logger<?> getLogger() {
-    LogstashCoreLogger logstashCoreLogger =
-        new LogstashCoreLogger(factory.getLogger(getClass().getName()));
-    return LoggerFactory.getLogger(logstashCoreLogger, Field.Builder.instance());
   }
 
   @Test
@@ -74,6 +79,42 @@ class LoggerTest extends TestBase {
     final ILoggingEvent event = listAppender.list.get(0);
     final String formattedMessage = event.getFormattedMessage();
     assertThat(formattedMessage).isEqualTo("hello null");
+  }
+
+  @Test
+  void testNullStringArgument() {
+    Logger<?> logger = getLogger();
+    String value = null;
+    logger.debug("hello {}", fb -> fb.only(fb.string("name", value)));
+
+    final ListAppender<ILoggingEvent> listAppender = getListAppender();
+    final ILoggingEvent event = listAppender.list.get(0);
+    final String formattedMessage = event.getFormattedMessage();
+    assertThat(formattedMessage).isEqualTo("hello [FAILED toString()]");
+  }
+
+  @Test
+  void testNullFieldName() {
+    Logger<?> logger = getLogger();
+    String value = "value";
+    logger.debug("hello {}", fb -> fb.only(fb.string(null, value)));
+
+    final ListAppender<ILoggingEvent> listAppender = getListAppender();
+    final ILoggingEvent event = listAppender.list.get(0);
+    final String formattedMessage = event.getFormattedMessage();
+    assertThat(formattedMessage).isEqualTo("hello value");
+  }
+
+  @Test
+  void testNullNumber() {
+    Logger<?> logger = getLogger();
+    Number value = null;
+    logger.debug("hello {}", fb -> fb.only(fb.number("name", value)));
+
+    final ListAppender<ILoggingEvent> listAppender = getListAppender();
+    final ILoggingEvent event = listAppender.list.get(0);
+    final String formattedMessage = event.getFormattedMessage();
+    assertThat(formattedMessage).isEqualTo("hello [FAILED toString()]");
   }
 
   @Test
@@ -242,5 +283,11 @@ class LoggerTest extends TestBase {
       Field[] fields = {name, age, father, mother, interests};
       return object(fieldName, fields);
     }
+  }
+
+  private Logger<?> getLogger() {
+    LogstashCoreLogger logstashCoreLogger =
+        new LogstashCoreLogger(factory.getLogger(getClass().getName()));
+    return LoggerFactory.getLogger(logstashCoreLogger, Field.Builder.instance());
   }
 }

--- a/logstash/src/test/java/com/tersesystems/echopraxia/logstash/LoggerTest.java
+++ b/logstash/src/test/java/com/tersesystems/echopraxia/logstash/LoggerTest.java
@@ -90,7 +90,7 @@ class LoggerTest extends TestBase {
     final ListAppender<ILoggingEvent> listAppender = getListAppender();
     final ILoggingEvent event = listAppender.list.get(0);
     final String formattedMessage = event.getFormattedMessage();
-    assertThat(formattedMessage).isEqualTo("hello [FAILED toString()]");
+    assertThat(formattedMessage).isEqualTo("hello null");
   }
 
   @Test
@@ -114,7 +114,43 @@ class LoggerTest extends TestBase {
     final ListAppender<ILoggingEvent> listAppender = getListAppender();
     final ILoggingEvent event = listAppender.list.get(0);
     final String formattedMessage = event.getFormattedMessage();
-    assertThat(formattedMessage).isEqualTo("hello [FAILED toString()]");
+    assertThat(formattedMessage).isEqualTo("hello null");
+  }
+
+  @Test
+  void testNullBoolean() {
+    Logger<?> logger = getLogger();
+    logger.debug("boolean is {}", fb -> fb.only(fb.bool("name", (Boolean) null)));
+
+    final ListAppender<ILoggingEvent> listAppender = getListAppender();
+    final ILoggingEvent event = listAppender.list.get(0);
+    final String message = event.getFormattedMessage();
+    assertThat(message).isEqualTo("boolean is null");
+  }
+
+  @Test
+  void testNullArrayElement() {
+    Logger<?> logger = getLogger();
+    String[] values = {"1", null, "3"};
+    logger.debug("array field is {}", fb -> fb.only(fb.array("arrayName", values)));
+
+    final ListAppender<ILoggingEvent> listAppender = getListAppender();
+    final ILoggingEvent event = listAppender.list.get(0);
+    final String message = event.getFormattedMessage();
+    assertThat(message).isEqualTo("array field is arrayName=[1, null, 3]");
+  }
+
+  @Test
+  void testNullObject() {
+    Logger<?> logger = getLogger();
+    logger.debug(
+        "object is {}", fb -> fb.only(fb.object("name", Field.Value.object((Field) null))));
+
+    final ListAppender<ILoggingEvent> listAppender = getListAppender();
+    final ILoggingEvent event = listAppender.list.get(0);
+    final String message = event.getFormattedMessage();
+    assertThat(message)
+        .isEqualTo("object is name={}"); // {} here is literally an object with no fields
   }
 
   @Test

--- a/semantic/src/jmh/java/com/tersesystems/echopraxia/semantic/SemanticLoggerBenchmarks.java
+++ b/semantic/src/jmh/java/com/tersesystems/echopraxia/semantic/SemanticLoggerBenchmarks.java
@@ -2,6 +2,7 @@ package com.tersesystems.echopraxia.semantic;
 
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
 
 @BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.NANOSECONDS)
@@ -14,14 +15,14 @@ public class SemanticLoggerBenchmarks {
       SemanticLoggerFactory.getLogger(
           String.class, s -> "Message {}", s -> b -> b.onlyString("name", s));
 
-  //  @Benchmark
-  //  public void info() {
-  //    // SemanticLoggerBenchmarks.info  avgt   25  97.199 ± 3.323  ns/op
-  //    logger.info("string");
-  //  }
+  @Benchmark
+  public void info() {
+    // SemanticLoggerBenchmarks.info  avgt   25  97.199 ± 3.323  ns/op
+    logger.info("string");
+  }
 
   @Benchmark
-  public void isInfoEnabled() {
-    logger.isInfoEnabled();
+  public void isInfoEnabled(Blackhole blackhole) {
+    blackhole.consume(logger.isInfoEnabled());
   }
 }

--- a/semantic/src/main/java/com/tersesystems/echopraxia/semantic/SemanticLogger.java
+++ b/semantic/src/main/java/com/tersesystems/echopraxia/semantic/SemanticLogger.java
@@ -4,6 +4,7 @@ import com.tersesystems.echopraxia.Condition;
 import com.tersesystems.echopraxia.Field;
 import com.tersesystems.echopraxia.core.CoreLogger;
 import java.util.function.Function;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * SemanticLogger interface built around a datatype.
@@ -16,56 +17,62 @@ import java.util.function.Function;
  */
 public interface SemanticLogger<DataType> {
 
+  @NotNull
   CoreLogger core();
 
   boolean isErrorEnabled();
 
-  boolean isErrorEnabled(Condition c);
+  boolean isErrorEnabled(@NotNull Condition c);
 
-  void error(DataType data);
+  void error(@NotNull DataType data);
 
-  void error(Condition c, DataType data);
+  void error(@NotNull Condition c, @NotNull DataType data);
 
   boolean isWarnEnabled();
 
-  boolean isWarnEnabled(Condition c);
+  boolean isWarnEnabled(@NotNull Condition c);
 
-  void warn(DataType data);
+  void warn(@NotNull DataType data);
 
-  void warn(Condition c, DataType data);
+  void warn(@NotNull Condition c, @NotNull DataType data);
 
   boolean isInfoEnabled();
 
-  boolean isInfoEnabled(Condition c);
+  boolean isInfoEnabled(@NotNull Condition c);
 
-  void info(DataType data);
+  void info(@NotNull DataType data);
 
-  void info(Condition c, DataType data);
+  void info(@NotNull Condition c, @NotNull DataType data);
 
   boolean isDebugEnabled();
 
-  boolean isDebugEnabled(Condition c);
+  boolean isDebugEnabled(@NotNull Condition c);
 
-  void debug(DataType data);
+  void debug(@NotNull DataType data);
 
-  void debug(Condition c, DataType data);
+  void debug(@NotNull Condition c, @NotNull DataType data);
 
   boolean isTraceEnabled();
 
-  boolean isTraceEnabled(Condition c);
+  boolean isTraceEnabled(@NotNull Condition c);
 
-  void trace(DataType data);
+  void trace(@NotNull DataType data);
 
-  void trace(Condition c, DataType data);
+  void trace(@NotNull Condition c, @NotNull DataType data);
 
-  SemanticLogger<DataType> withCondition(Condition c);
+  @NotNull
+  SemanticLogger<DataType> withCondition(@NotNull Condition c);
 
-  SemanticLogger<DataType> withFields(Field.BuilderFunction<Field.Builder> f);
+  @NotNull
+  SemanticLogger<DataType> withFields(@NotNull Field.BuilderFunction<Field.Builder> f);
 
+  @NotNull
   SemanticLogger<DataType> withThreadContext();
 
+  @NotNull
   <FB extends Field.Builder> SemanticLogger<DataType> withFields(
-      Field.BuilderFunction<FB> f, FB builder);
+      @NotNull Field.BuilderFunction<FB> f, @NotNull FB builder);
 
-  SemanticLogger<DataType> withMessage(Function<DataType, String> messageFunction);
+  @NotNull
+  SemanticLogger<DataType> withMessage(@NotNull Function<DataType, String> messageFunction);
 }

--- a/semantic/src/main/java/com/tersesystems/echopraxia/semantic/SemanticLoggerFactory.java
+++ b/semantic/src/main/java/com/tersesystems/echopraxia/semantic/SemanticLoggerFactory.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import org.jetbrains.annotations.NotNull;
 
 /**
  * The semantic logger factory. This is used to render complex objects specifically on their type.
@@ -188,7 +189,7 @@ public class SemanticLoggerFactory {
     }
 
     @Override
-    public CoreLogger core() {
+    public @NotNull CoreLogger core() {
       return core;
     }
 
@@ -210,19 +211,19 @@ public class SemanticLoggerFactory {
     }
 
     @Override
-    public boolean isErrorEnabled(Condition c) {
+    public boolean isErrorEnabled(@NotNull Condition c) {
       return core.isEnabled(Level.ERROR, c);
     }
 
     @Override
-    public void error(DataType data) {
+    public void error(@NotNull DataType data) {
       if (core.isEnabled(Level.ERROR)) {
         core.log(Level.ERROR, convertMessage(data), builderFunction.apply(data), builder);
       }
     }
 
     @Override
-    public void error(Condition c, DataType data) {
+    public void error(@NotNull Condition c, @NotNull DataType data) {
       if (core.isEnabled(Level.ERROR, c)) {
         core.log(Level.ERROR, convertMessage(data), builderFunction.apply(data), builder);
       }
@@ -234,7 +235,7 @@ public class SemanticLoggerFactory {
     }
 
     @Override
-    public boolean isWarnEnabled(Condition c) {
+    public boolean isWarnEnabled(@NotNull Condition c) {
       return core.isEnabled(Level.WARN, c);
     }
 
@@ -243,14 +244,14 @@ public class SemanticLoggerFactory {
     }
 
     @Override
-    public void warn(DataType data) {
+    public void warn(@NotNull DataType data) {
       if (core.isEnabled(Level.WARN)) {
         core.log(Level.WARN, convertMessage(data), builderFunction.apply(data), builder);
       }
     }
 
     @Override
-    public void warn(Condition c, DataType data) {
+    public void warn(@NotNull Condition c, @NotNull DataType data) {
       if (core.isEnabled(Level.WARN, c)) {
         core.log(Level.WARN, convertMessage(data), builderFunction.apply(data), builder);
       }
@@ -262,19 +263,19 @@ public class SemanticLoggerFactory {
     }
 
     @Override
-    public boolean isInfoEnabled(Condition c) {
+    public boolean isInfoEnabled(@NotNull Condition c) {
       return core.isEnabled(Level.INFO, c);
     }
 
     @Override
-    public void info(DataType data) {
+    public void info(@NotNull DataType data) {
       if (core.isEnabled(Level.INFO)) {
         core.log(Level.INFO, convertMessage(data), builderFunction.apply(data), builder);
       }
     }
 
     @Override
-    public void info(Condition c, DataType data) {
+    public void info(@NotNull Condition c, @NotNull DataType data) {
       if (core.isEnabled(Level.INFO, c)) {
         core.log(Level.INFO, convertMessage(data), builderFunction.apply(data), builder);
       }
@@ -286,19 +287,19 @@ public class SemanticLoggerFactory {
     }
 
     @Override
-    public boolean isDebugEnabled(Condition c) {
+    public boolean isDebugEnabled(@NotNull Condition c) {
       return core.isEnabled(Level.DEBUG, c);
     }
 
     @Override
-    public void debug(DataType data) {
+    public void debug(@NotNull DataType data) {
       if (core.isEnabled(Level.DEBUG)) {
         core.log(Level.DEBUG, convertMessage(data), builderFunction.apply(data), builder);
       }
     }
 
     @Override
-    public void debug(Condition c, DataType data) {
+    public void debug(@NotNull Condition c, @NotNull DataType data) {
       if (core.isEnabled(Level.DEBUG, c)) {
         core.log(Level.DEBUG, convertMessage(data), builderFunction.apply(data), builder);
       }
@@ -310,38 +311,39 @@ public class SemanticLoggerFactory {
     }
 
     @Override
-    public boolean isTraceEnabled(Condition c) {
+    public boolean isTraceEnabled(@NotNull Condition c) {
       return core.isEnabled(Level.TRACE, c);
     }
 
     @Override
-    public void trace(DataType data) {
+    public void trace(@NotNull DataType data) {
       if (core.isEnabled(Level.TRACE)) {
         core.log(Level.TRACE, convertMessage(data), builderFunction.apply(data), builder);
       }
     }
 
     @Override
-    public void trace(Condition c, DataType data) {
+    public void trace(@NotNull Condition c, @NotNull DataType data) {
       if (core.isEnabled(Level.TRACE, c)) {
         core.log(Level.TRACE, convertMessage(data), builderFunction.apply(data), builder);
       }
     }
 
     @Override
-    public SemanticLogger<DataType> withCondition(Condition c) {
+    public @NotNull SemanticLogger<DataType> withCondition(@NotNull Condition c) {
       final CoreLogger coreLogger = core.withCondition(c);
       return new SemanticLoggerFactory.Impl<>(
           coreLogger, builder, messageFunction, builderFunction);
     }
 
     @Override
-    public SemanticLogger<DataType> withFields(Field.BuilderFunction<Field.Builder> f) {
+    public @NotNull SemanticLogger<DataType> withFields(
+        Field.@NotNull BuilderFunction<Field.Builder> f) {
       return withFields(f, builder);
     }
 
     @Override
-    public SemanticLogger<DataType> withThreadContext() {
+    public @NotNull SemanticLogger<DataType> withThreadContext() {
       Function<Supplier<Map<String, String>>, Supplier<List<Field>>> mapTransform =
           mapSupplier ->
               () ->
@@ -354,15 +356,16 @@ public class SemanticLoggerFactory {
     }
 
     @Override
-    public <CFB extends Field.Builder> SemanticLogger<DataType> withFields(
-        Field.BuilderFunction<CFB> ctxBuilderF, CFB ctxBuilder) {
+    public <CFB extends Field.Builder> @NotNull SemanticLogger<DataType> withFields(
+        Field.@NotNull BuilderFunction<CFB> ctxBuilderF, @NotNull CFB ctxBuilder) {
       final CoreLogger coreLogger = core.withFields(ctxBuilderF, ctxBuilder);
       return new SemanticLoggerFactory.Impl<>(
           coreLogger, builder, messageFunction, builderFunction);
     }
 
     @Override
-    public SemanticLogger<DataType> withMessage(Function<DataType, String> messageFunction) {
+    public @NotNull SemanticLogger<DataType> withMessage(
+        @NotNull Function<DataType, String> messageFunction) {
       return new SemanticLoggerFactory.Impl<>(core, builder, messageFunction, builderFunction);
     }
   }


### PR DESCRIPTION
It should not be possible to crash a field builder even if you pass nulls in.

Add jetbrains annotations in, add tests for nulls everywhere, and create fake field names if a null name is passed in.