### PR TITLE
Ensure location info is transparent

### DIFF
--- a/api/src/main/java/com/tersesystems/echopraxia/core/CoreLoggerFactory.java
+++ b/api/src/main/java/com/tersesystems/echopraxia/core/CoreLoggerFactory.java
@@ -32,7 +32,9 @@ public class CoreLoggerFactory {
       ServiceLoader<CoreLoggerProvider> loader = ServiceLoader.load(CoreLoggerProvider.class);
       Iterator<CoreLoggerProvider> iterator = loader.iterator();
       if (iterator.hasNext()) {
-        return iterator.next();
+        final CoreLoggerProvider provider = iterator.next();
+        provider.initialize();
+        return provider;
       } else {
         String msg = "No CoreLoggerProvider implementation found in classpath!";
         throw new ServiceConfigurationError(msg);

--- a/api/src/main/java/com/tersesystems/echopraxia/core/CoreLoggerProvider.java
+++ b/api/src/main/java/com/tersesystems/echopraxia/core/CoreLoggerProvider.java
@@ -9,6 +9,8 @@ import org.jetbrains.annotations.NotNull;
  */
 public interface CoreLoggerProvider {
 
+  void initialize();
+
   @NotNull
   CoreLogger getLogger(@NotNull Class<?> clazz);
 

--- a/log4j/src/main/java/com/tersesystems/echopraxia/log4j/Log4JCoreLoggerProvider.java
+++ b/log4j/src/main/java/com/tersesystems/echopraxia/log4j/Log4JCoreLoggerProvider.java
@@ -4,9 +4,29 @@ import com.tersesystems.echopraxia.core.CoreLogger;
 import com.tersesystems.echopraxia.core.CoreLoggerProvider;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.spi.ExtendedLogger;
+import org.apache.logging.log4j.spi.LoggerContext;
 import org.jetbrains.annotations.NotNull;
 
 public class Log4JCoreLoggerProvider implements CoreLoggerProvider {
+
+  private LoggerContext context;
+
+  @Override
+  public void initialize() {
+    context = LogManager.getContext();
+
+    // https://issues.apache.org/jira/browse/LOG4J2-2792
+    // https://logging.apache.org/log4j/2.x/manual/async.html#Location
+    // https://logging.apache.org/log4j/2.x/manual/layouts.html#LocationInformation
+    //
+    // Goes through StackLocator and StackLocatorUtil to calculate the location.
+    // LocationAwareLogEventFactory seems to be the entry point to an event.
+    // after that it comes from getSource() which has a StackTraceElement.
+    //
+    // Does not seem to be anything like getFrameworkPackages to filter the source,
+    // I think you would have to do this through a custom JSON exception resolver.
+    // and again for any other layouts.
+  }
 
   @Override
   public @NotNull CoreLogger getLogger(@NotNull Class<?> clazz) {
@@ -15,6 +35,6 @@ public class Log4JCoreLoggerProvider implements CoreLoggerProvider {
 
   @Override
   public @NotNull CoreLogger getLogger(@NotNull String name) {
-    return new Log4JCoreLogger((ExtendedLogger) LogManager.getLogger(name));
+    return new Log4JCoreLogger(context.getLogger(name));
   }
 }

--- a/log4j/src/test/resources/log4j2.xml
+++ b/log4j/src/test/resources/log4j2.xml
@@ -6,7 +6,7 @@
 
     <Appenders>
         <Console name="Console" target="SYSTEM_OUT" follow="true">
-            <JsonTemplateLayout eventTemplateUri="classpath:LogstashJsonEventLayoutV1.json">
+            <JsonTemplateLayout eventTemplateUri="classpath:LogstashJsonEventLayoutV1.json" locationInfoEnabled="true">
                 <EventTemplateAdditionalField
                         key="marker"
                         format="JSON"


### PR DESCRIPTION
If location info is enabled in Log4J or in Logback, we want to show the info as coming from the `logger.info` method of Echopraxia, rather than the logging implementation several layers down.

Logback has a `frameworkPackages` that can be used to filter out traces from the caller info.

Using the following layout

```xml
    <appender name="TEXT" class="ch.qos.logback.core.ConsoleAppender">
        <encoder>
            <pattern>%-5level [%thread]: %message%n%caller{2}</pattern>
        </encoder>
    </appender>
```

We will get an ugly:

```
INFO  [main]: This renders with the last access date
Caller+0	 at com.tersesystems.echopraxia.logstash.LogstashCoreLogger.log(LogstashCoreLogger.java:170)
Caller+1	 at com.tersesystems.echopraxia.Logger.info(Logger.java:357)
INFO  [main]: This renders the updated date
Caller+0	 at com.tersesystems.echopraxia.logstash.LogstashCoreLogger.log(LogstashCoreLogger.java:170)
Caller+1	 at com.tersesystems.echopraxia.Logger.info(Logger.java:357)
INFO  [main]: hi there person={Abe, 1, father={Bert, 35, father=null, mother=null, interests=[keyboards]}, mother={Candace, 30, father=null, mother=null, interests=[iceskating]}, interests=[yodelling]}
Caller+0	 at com.tersesystems.echopraxia.logstash.LogstashCoreLogger.log(LogstashCoreLogger.java:211)
Caller+1	 at com.tersesystems.echopraxia.Logger.info(Logger.java:368)
INFO  [main]: This statement has MDC values in context
Caller+0	 at com.tersesystems.echopraxia.logstash.LogstashCoreLogger.log(LogstashCoreLogger.java:170)
Caller+1	 at com.tersesystems.echopraxia.Logger.info(Logger.java:357)
```

But when adding the echopraxia package in:

```
> Task :example:Main.main()
INFO  [main]: This renders with the last access date
Caller+0	 at example.Main.doStuff(Main.java:51)
Caller+1	 at example.Main.main(Main.java:45)
INFO  [main]: This renders the updated date
Caller+0	 at example.Main.doStuff(Main.java:57)
Caller+1	 at example.Main.main(Main.java:45)
INFO  [main]: hi there person={Abe, 1, father={Bert, 35, father=null, mother=null, interests=[keyboards]}, mother={Candace, 30, father=null, mother=null, interests=[iceskating]}, interests=[yodelling]}
Caller+0	 at example.Main.doStuff(Main.java:75)
Caller+1	 at example.Main.main(Main.java:45)
INFO  [main]: This statement has MDC values in context
Caller+0	 at example.Main.doStuff(Main.java:88)
Caller+1	 at example.Main.main(Main.java:45)
```