### PR TITLE
Create FQCN for Log4J

### DIFF
--- a/api/src/main/java/com/tersesystems/echopraxia/LoggerFactory.java
+++ b/api/src/main/java/com/tersesystems/echopraxia/LoggerFactory.java
@@ -12,6 +12,8 @@ import org.jetbrains.annotations.NotNull;
  */
 public class LoggerFactory {
 
+  private static final String FQCN = Logger.class.getName();
+
   /**
    * Creates a logger using the given class name.
    *
@@ -20,7 +22,7 @@ public class LoggerFactory {
    */
   @NotNull
   public static Logger<Field.Builder> getLogger(Class<?> clazz) {
-    final CoreLogger core = CoreLoggerFactory.getLogger(clazz);
+    final CoreLogger core = CoreLoggerFactory.getLogger(FQCN, clazz);
     return getLogger(core, Field.Builder.instance());
   }
 
@@ -47,7 +49,7 @@ public class LoggerFactory {
    */
   @NotNull
   public static Logger<Field.Builder> getLogger(@NotNull String name) {
-    final CoreLogger core = CoreLoggerFactory.getLogger(name);
+    final CoreLogger core = CoreLoggerFactory.getLogger(FQCN, name);
     return getLogger(core, Field.Builder.instance());
   }
 
@@ -73,7 +75,7 @@ public class LoggerFactory {
    */
   @NotNull
   public static Logger<Field.Builder> getLogger() {
-    CoreLogger core = CoreLoggerFactory.getLogger(Caller.resolveClassName());
+    CoreLogger core = CoreLoggerFactory.getLogger(FQCN, Caller.resolveClassName());
     return getLogger(core, Field.Builder.instance());
   }
 
@@ -86,7 +88,7 @@ public class LoggerFactory {
    */
   @NotNull
   public static <FB extends Field.Builder> Logger<FB> getLogger(@NotNull FB fieldBuilder) {
-    CoreLogger core = CoreLoggerFactory.getLogger(Caller.resolveClassName());
+    CoreLogger core = CoreLoggerFactory.getLogger(FQCN, Caller.resolveClassName());
     return getLogger(core, fieldBuilder);
   }
 

--- a/api/src/main/java/com/tersesystems/echopraxia/core/CoreLoggerFactory.java
+++ b/api/src/main/java/com/tersesystems/echopraxia/core/CoreLoggerFactory.java
@@ -13,18 +13,13 @@ import org.jetbrains.annotations.NotNull;
 public class CoreLoggerFactory {
 
   @NotNull
-  public static CoreLogger getLogger(@NotNull Class<?> clazz) {
-    return LazyHolder.INSTANCE.getLogger(clazz);
+  public static CoreLogger getLogger(String fqcn, @NotNull Class<?> clazz) {
+    return LazyHolder.INSTANCE.getLogger(fqcn, clazz);
   }
 
   @NotNull
-  public static CoreLogger getLogger(@NotNull String name) {
-    return LazyHolder.INSTANCE.getLogger(name);
-  }
-
-  @NotNull
-  public static CoreLogger getLogger() {
-    return getLogger(Caller.resolveClassName());
+  public static CoreLogger getLogger(String fqcn, @NotNull String name) {
+    return LazyHolder.INSTANCE.getLogger(fqcn, name);
   }
 
   private static class LazyHolder {

--- a/api/src/main/java/com/tersesystems/echopraxia/core/CoreLoggerProvider.java
+++ b/api/src/main/java/com/tersesystems/echopraxia/core/CoreLoggerProvider.java
@@ -12,8 +12,8 @@ public interface CoreLoggerProvider {
   void initialize();
 
   @NotNull
-  CoreLogger getLogger(@NotNull Class<?> clazz);
+  CoreLogger getLogger(@NotNull String fqcn, @NotNull Class<?> clazz);
 
   @NotNull
-  CoreLogger getLogger(@NotNull String name);
+  CoreLogger getLogger(@NotNull String fqcn, @NotNull String name);
 }

--- a/example/src/main/java/example/Main.java
+++ b/example/src/main/java/example/Main.java
@@ -10,7 +10,6 @@ import com.tersesystems.echopraxia.LoggerFactory;
 import com.tersesystems.echopraxia.core.Caller;
 import com.tersesystems.echopraxia.core.CoreLogger;
 import com.tersesystems.echopraxia.core.CoreLoggerFactory;
-
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.util.Date;
@@ -180,7 +179,9 @@ public class Main {
 
   static class MyLoggerFactory {
     public static MyLogger getLogger() {
-      return new MyLogger(CoreLoggerFactory.getLogger(MyLogger.class.getName(), Caller.resolveClassName()), myFieldBuilder);
+      return new MyLogger(
+          CoreLoggerFactory.getLogger(MyLogger.class.getName(), Caller.resolveClassName()),
+          myFieldBuilder);
     }
   }
 }

--- a/example/src/main/java/example/Main.java
+++ b/example/src/main/java/example/Main.java
@@ -7,8 +7,10 @@ import com.tersesystems.echopraxia.Condition;
 import com.tersesystems.echopraxia.Field;
 import com.tersesystems.echopraxia.Logger;
 import com.tersesystems.echopraxia.LoggerFactory;
+import com.tersesystems.echopraxia.core.Caller;
 import com.tersesystems.echopraxia.core.CoreLogger;
 import com.tersesystems.echopraxia.core.CoreLoggerFactory;
+
 import java.time.Instant;
 import java.time.format.DateTimeFormatter;
 import java.util.Date;
@@ -178,7 +180,7 @@ public class Main {
 
   static class MyLoggerFactory {
     public static MyLogger getLogger() {
-      return new MyLogger(CoreLoggerFactory.getLogger(), myFieldBuilder);
+      return new MyLogger(CoreLoggerFactory.getLogger(MyLogger.class.getName(), Caller.resolveClassName()), myFieldBuilder);
     }
   }
 }

--- a/fluent/src/main/java/com/tersesystems/echopraxia/fluent/FluentLoggerFactory.java
+++ b/fluent/src/main/java/com/tersesystems/echopraxia/fluent/FluentLoggerFactory.java
@@ -1,7 +1,6 @@
 package com.tersesystems.echopraxia.fluent;
 
 import com.tersesystems.echopraxia.Field;
-import com.tersesystems.echopraxia.LoggerFactory;
 import com.tersesystems.echopraxia.core.Caller;
 import com.tersesystems.echopraxia.core.CoreLogger;
 import com.tersesystems.echopraxia.core.CoreLoggerFactory;

--- a/fluent/src/main/java/com/tersesystems/echopraxia/fluent/FluentLoggerFactory.java
+++ b/fluent/src/main/java/com/tersesystems/echopraxia/fluent/FluentLoggerFactory.java
@@ -4,9 +4,11 @@ import com.tersesystems.echopraxia.Field;
 import com.tersesystems.echopraxia.LoggerFactory;
 import com.tersesystems.echopraxia.core.Caller;
 import com.tersesystems.echopraxia.core.CoreLogger;
+import com.tersesystems.echopraxia.core.CoreLoggerFactory;
 
 /** The factory for FluentLogger. */
 public class FluentLoggerFactory {
+  private static final String FQCN = FluentLogger.class.getName();
 
   /**
    * Creates a logger using the given class name.
@@ -27,7 +29,7 @@ public class FluentLoggerFactory {
    * @param <FB> the type of field builder.
    */
   public static <FB extends Field.Builder> FluentLogger<FB> getLogger(Class<?> clazz, FB builder) {
-    CoreLogger coreLogger = LoggerFactory.getLogger(clazz).core();
+    CoreLogger coreLogger = CoreLoggerFactory.getLogger(FQCN, clazz);
     return getLogger(coreLogger, builder);
   }
 
@@ -50,7 +52,7 @@ public class FluentLoggerFactory {
    * @return the logger.
    */
   public static <FB extends Field.Builder> FluentLogger<FB> getLogger(String name, FB builder) {
-    CoreLogger coreLogger = LoggerFactory.getLogger(name).core();
+    CoreLogger coreLogger = CoreLoggerFactory.getLogger(FQCN, name);
     return getLogger(coreLogger, builder);
   }
 

--- a/log4j/src/jmh/java/com/tersesystems/echopraxia/log4j/CoreLoggerBenchmarks.java
+++ b/log4j/src/jmh/java/com/tersesystems/echopraxia/log4j/CoreLoggerBenchmarks.java
@@ -3,7 +3,6 @@ package com.tersesystems.echopraxia.log4j;
 import com.tersesystems.echopraxia.Field;
 import com.tersesystems.echopraxia.Level;
 import com.tersesystems.echopraxia.Logger;
-import com.tersesystems.echopraxia.LoggerFactory;
 import com.tersesystems.echopraxia.core.CoreLogger;
 import com.tersesystems.echopraxia.core.CoreLoggerFactory;
 import java.util.concurrent.TimeUnit;
@@ -16,7 +15,8 @@ import org.openjdk.jmh.infra.Blackhole;
 @Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
 @Fork(1)
 public class CoreLoggerBenchmarks {
-  private static final CoreLogger logger = CoreLoggerFactory.getLogger(Logger.class.getName(), CoreLoggerBenchmarks.class.getName());
+  private static final CoreLogger logger =
+      CoreLoggerFactory.getLogger(Logger.class.getName(), CoreLoggerBenchmarks.class.getName());
   private static final Exception exception = new RuntimeException();
   private static final Field.Builder builder = Field.Builder.instance();
 

--- a/log4j/src/jmh/java/com/tersesystems/echopraxia/log4j/CoreLoggerBenchmarks.java
+++ b/log4j/src/jmh/java/com/tersesystems/echopraxia/log4j/CoreLoggerBenchmarks.java
@@ -2,6 +2,8 @@ package com.tersesystems.echopraxia.log4j;
 
 import com.tersesystems.echopraxia.Field;
 import com.tersesystems.echopraxia.Level;
+import com.tersesystems.echopraxia.Logger;
+import com.tersesystems.echopraxia.LoggerFactory;
 import com.tersesystems.echopraxia.core.CoreLogger;
 import com.tersesystems.echopraxia.core.CoreLoggerFactory;
 import java.util.concurrent.TimeUnit;
@@ -14,7 +16,7 @@ import org.openjdk.jmh.infra.Blackhole;
 @Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
 @Fork(1)
 public class CoreLoggerBenchmarks {
-  private static final CoreLogger logger = CoreLoggerFactory.getLogger();
+  private static final CoreLogger logger = CoreLoggerFactory.getLogger(Logger.class.getName(), CoreLoggerBenchmarks.class.getName());
   private static final Exception exception = new RuntimeException();
   private static final Field.Builder builder = Field.Builder.instance();
 

--- a/log4j/src/main/java/com/tersesystems/echopraxia/log4j/Log4JCoreLogger.java
+++ b/log4j/src/main/java/com/tersesystems/echopraxia/log4j/Log4JCoreLogger.java
@@ -39,7 +39,7 @@ public class Log4JCoreLogger implements CoreLogger {
     this.fqcn = fqcn;
     this.logger =
         new ExtendedLoggerWrapper(
-             log4jLogger, log4jLogger.getName(), log4jLogger.getMessageFactory());
+            log4jLogger, log4jLogger.getName(), log4jLogger.getMessageFactory());
     this.context = new Log4JLoggingContext();
     this.condition = Condition.always();
     this.executor = ForkJoinPool.commonPool();
@@ -54,7 +54,7 @@ public class Log4JCoreLogger implements CoreLogger {
     this.fqcn = fqcn;
     this.logger =
         new ExtendedLoggerWrapper(
-          log4jLogger, log4jLogger.getName(), log4jLogger.getMessageFactory());
+            log4jLogger, log4jLogger.getName(), log4jLogger.getMessageFactory());
     ;
     this.context = context;
     this.condition = condition;
@@ -134,7 +134,7 @@ public class Log4JCoreLogger implements CoreLogger {
       return;
     }
     logger.logIfEnabled(
-      fqcn, convertLevel(level), context.getMarker(), createMessage(message), null);
+        fqcn, convertLevel(level), context.getMarker(), createMessage(message), null);
   }
 
   @Override
@@ -158,7 +158,7 @@ public class Log4JCoreLogger implements CoreLogger {
       return;
     }
     logger.logIfEnabled(
-      fqcn,
+        fqcn,
         convertLevel(level),
         context.getMarker(),
         createMessage(message, Collections.emptyList()),

--- a/log4j/src/main/java/com/tersesystems/echopraxia/log4j/Log4JCoreLogger.java
+++ b/log4j/src/main/java/com/tersesystems/echopraxia/log4j/Log4JCoreLogger.java
@@ -21,7 +21,6 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.ThreadContext;
 import org.apache.logging.log4j.message.Message;
-import org.apache.logging.log4j.spi.AbstractLogger;
 import org.apache.logging.log4j.spi.ExtendedLogger;
 import org.apache.logging.log4j.spi.ExtendedLoggerWrapper;
 import org.jetbrains.annotations.NotNull;
@@ -30,30 +29,32 @@ import org.jetbrains.annotations.Nullable;
 /** A core logger using the Log4J API. */
 public class Log4JCoreLogger implements CoreLogger {
 
-  private static final String FQCN = Log4JCoreLogger.class.getName();
-
   private final ExtendedLoggerWrapper logger;
   private final Log4JLoggingContext context;
   private final Condition condition;
   private final Executor executor;
+  private final String fqcn;
 
-  Log4JCoreLogger(Logger log4jLogger) {
+  Log4JCoreLogger(@NotNull String fqcn, ExtendedLogger log4jLogger) {
+    this.fqcn = fqcn;
     this.logger =
         new ExtendedLoggerWrapper(
-            (AbstractLogger) log4jLogger, log4jLogger.getName(), log4jLogger.getMessageFactory());
+             log4jLogger, log4jLogger.getName(), log4jLogger.getMessageFactory());
     this.context = new Log4JLoggingContext();
     this.condition = Condition.always();
     this.executor = ForkJoinPool.commonPool();
   }
 
   protected Log4JCoreLogger(
+      String fqcn,
       ExtendedLogger log4jLogger,
       Log4JLoggingContext context,
       Condition condition,
       Executor executor) {
+    this.fqcn = fqcn;
     this.logger =
         new ExtendedLoggerWrapper(
-            (AbstractLogger) log4jLogger, log4jLogger.getName(), log4jLogger.getMessageFactory());
+          log4jLogger, log4jLogger.getName(), log4jLogger.getMessageFactory());
     ;
     this.context = context;
     this.condition = condition;
@@ -73,7 +74,7 @@ public class Log4JCoreLogger implements CoreLogger {
   public <B extends Field.Builder> @NotNull CoreLogger withFields(
       Field.@NotNull BuilderFunction<B> f, @NotNull B builder) {
     Log4JLoggingContext newContext = new Log4JLoggingContext(() -> f.apply(builder), null);
-    return new Log4JCoreLogger(logger, context.and(newContext), condition, executor);
+    return new Log4JCoreLogger(fqcn, logger, context.and(newContext), condition, executor);
   }
 
   @Override
@@ -81,7 +82,7 @@ public class Log4JCoreLogger implements CoreLogger {
       @NotNull Function<Supplier<Map<String, String>>, Supplier<List<Field>>> mapTransform) {
     Supplier<List<Field>> fieldSupplier = mapTransform.apply(ThreadContext::getImmutableContext);
     Log4JLoggingContext newContext = new Log4JLoggingContext(fieldSupplier, null);
-    return new Log4JCoreLogger(logger, this.context.and(newContext), condition, executor);
+    return new Log4JCoreLogger(fqcn, logger, this.context.and(newContext), condition, executor);
   }
 
   @Override
@@ -93,20 +94,20 @@ public class Log4JCoreLogger implements CoreLogger {
       if (this.condition == Condition.never()) {
         return this;
       }
-      return new Log4JCoreLogger(logger, context, condition, executor);
+      return new Log4JCoreLogger(fqcn, logger, context, condition, executor);
     }
-    return new Log4JCoreLogger(logger, context, this.condition.and(condition), executor);
+    return new Log4JCoreLogger(fqcn, logger, context, this.condition.and(condition), executor);
   }
 
   @Override
   public @NotNull CoreLogger withExecutor(@NotNull Executor executor) {
-    return new Log4JCoreLogger(logger, context, this.condition, executor);
+    return new Log4JCoreLogger(fqcn, logger, context, this.condition, executor);
   }
 
   @NotNull
   public CoreLogger withMarker(@NotNull Marker marker) {
     Log4JLoggingContext newContext = new Log4JLoggingContext(Collections::emptyList, marker);
-    return new Log4JCoreLogger(logger, this.context.and(newContext), condition, executor);
+    return new Log4JCoreLogger(fqcn, logger, this.context.and(newContext), condition, executor);
   }
 
   @Override
@@ -133,7 +134,7 @@ public class Log4JCoreLogger implements CoreLogger {
       return;
     }
     logger.logIfEnabled(
-        FQCN, convertLevel(level), context.getMarker(), createMessage(message), null);
+      fqcn, convertLevel(level), context.getMarker(), createMessage(message), null);
   }
 
   @Override
@@ -148,7 +149,7 @@ public class Log4JCoreLogger implements CoreLogger {
     final List<Field> argumentFields = f.apply(builder);
     final Throwable e = findThrowable(argumentFields);
     final Message message = createMessage(messageTemplate, argumentFields);
-    logger.logIfEnabled(FQCN, convertLevel(level), context.getMarker(), message, e);
+    logger.logIfEnabled(fqcn, convertLevel(level), context.getMarker(), message, e);
   }
 
   @Override
@@ -157,7 +158,7 @@ public class Log4JCoreLogger implements CoreLogger {
       return;
     }
     logger.logIfEnabled(
-        FQCN,
+      fqcn,
         convertLevel(level),
         context.getMarker(),
         createMessage(message, Collections.emptyList()),

--- a/log4j/src/main/java/com/tersesystems/echopraxia/log4j/Log4JCoreLoggerProvider.java
+++ b/log4j/src/main/java/com/tersesystems/echopraxia/log4j/Log4JCoreLoggerProvider.java
@@ -3,6 +3,7 @@ package com.tersesystems.echopraxia.log4j;
 import com.tersesystems.echopraxia.core.CoreLogger;
 import com.tersesystems.echopraxia.core.CoreLoggerProvider;
 import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.spi.ExtendedLogger;
 import org.jetbrains.annotations.NotNull;
 
 public class Log4JCoreLoggerProvider implements CoreLoggerProvider {
@@ -11,12 +12,12 @@ public class Log4JCoreLoggerProvider implements CoreLoggerProvider {
   public void initialize() {}
 
   @Override
-  public @NotNull CoreLogger getLogger(@NotNull Class<?> clazz) {
-    return getLogger(clazz.getName());
+  public @NotNull CoreLogger getLogger(@NotNull String fqcn, @NotNull Class<?> clazz) {
+    return getLogger(fqcn, clazz.getName());
   }
 
   @Override
-  public @NotNull CoreLogger getLogger(@NotNull String name) {
-    return new Log4JCoreLogger(LogManager.getLogger(name));
+  public @NotNull CoreLogger getLogger(@NotNull String fqcn, @NotNull String name) {
+    return new Log4JCoreLogger(fqcn, (ExtendedLogger) LogManager.getLogger(name));
   }
 }

--- a/log4j/src/main/java/com/tersesystems/echopraxia/log4j/Log4JCoreLoggerProvider.java
+++ b/log4j/src/main/java/com/tersesystems/echopraxia/log4j/Log4JCoreLoggerProvider.java
@@ -3,7 +3,6 @@ package com.tersesystems.echopraxia.log4j;
 import com.tersesystems.echopraxia.core.CoreLogger;
 import com.tersesystems.echopraxia.core.CoreLoggerProvider;
 import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.spi.ExtendedLogger;
 import org.apache.logging.log4j.spi.LoggerContext;
 import org.jetbrains.annotations.NotNull;
 
@@ -23,9 +22,22 @@ public class Log4JCoreLoggerProvider implements CoreLoggerProvider {
     // LocationAwareLogEventFactory seems to be the entry point to an event.
     // after that it comes from getSource() which has a StackTraceElement.
     //
-    // Does not seem to be anything like getFrameworkPackages to filter the source,
-    // I think you would have to do this through a custom JSON exception resolver.
-    // and again for any other layouts.
+    // From https://logging.apache.org/log4j/2.x/faq.html#logger-wrapper
+    //
+    // Log4j remembers the fully qualified class name (FQCN) of the logger and uses this to walk the
+    // stack trace for every log event when configured to print location. (Be aware that logging
+    // with location is slow and may impact the performance of your application.)
+    //
+    // The problem with custom logger wrappers is that they have a different FQCN than the actual
+    // logger, so Log4j can’t find the place where your custom logger was called.
+    //
+    // The solution is to provide the correct FQCN. The easiest way to do this is to let Log4j
+    // generate the logger wrapper for you. Log4j comes with a Logger wrapper generator tool. This
+    // tool was originally meant to support custom log levels and is documented here.
+    //
+    // The generated logger code will take care of the FQCN.
+    //
+    // https://logging.apache.org/log4j/2.x/manual/customloglevels.html#CustomLoggers
   }
 
   @Override

--- a/log4j/src/main/java/com/tersesystems/echopraxia/log4j/Log4JCoreLoggerProvider.java
+++ b/log4j/src/main/java/com/tersesystems/echopraxia/log4j/Log4JCoreLoggerProvider.java
@@ -3,42 +3,12 @@ package com.tersesystems.echopraxia.log4j;
 import com.tersesystems.echopraxia.core.CoreLogger;
 import com.tersesystems.echopraxia.core.CoreLoggerProvider;
 import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.spi.LoggerContext;
 import org.jetbrains.annotations.NotNull;
 
 public class Log4JCoreLoggerProvider implements CoreLoggerProvider {
 
-  private LoggerContext context;
-
   @Override
-  public void initialize() {
-    context = LogManager.getContext();
-
-    // https://issues.apache.org/jira/browse/LOG4J2-2792
-    // https://logging.apache.org/log4j/2.x/manual/async.html#Location
-    // https://logging.apache.org/log4j/2.x/manual/layouts.html#LocationInformation
-    //
-    // Goes through StackLocator and StackLocatorUtil to calculate the location.
-    // LocationAwareLogEventFactory seems to be the entry point to an event.
-    // after that it comes from getSource() which has a StackTraceElement.
-    //
-    // From https://logging.apache.org/log4j/2.x/faq.html#logger-wrapper
-    //
-    // Log4j remembers the fully qualified class name (FQCN) of the logger and uses this to walk the
-    // stack trace for every log event when configured to print location. (Be aware that logging
-    // with location is slow and may impact the performance of your application.)
-    //
-    // The problem with custom logger wrappers is that they have a different FQCN than the actual
-    // logger, so Log4j can’t find the place where your custom logger was called.
-    //
-    // The solution is to provide the correct FQCN. The easiest way to do this is to let Log4j
-    // generate the logger wrapper for you. Log4j comes with a Logger wrapper generator tool. This
-    // tool was originally meant to support custom log levels and is documented here.
-    //
-    // The generated logger code will take care of the FQCN.
-    //
-    // https://logging.apache.org/log4j/2.x/manual/customloglevels.html#CustomLoggers
-  }
+  public void initialize() {}
 
   @Override
   public @NotNull CoreLogger getLogger(@NotNull Class<?> clazz) {
@@ -47,6 +17,6 @@ public class Log4JCoreLoggerProvider implements CoreLoggerProvider {
 
   @Override
   public @NotNull CoreLogger getLogger(@NotNull String name) {
-    return new Log4JCoreLogger(context.getLogger(name));
+    return new Log4JCoreLogger(LogManager.getLogger(name));
   }
 }

--- a/log4j/src/test/java/com/tersesystems/echopraxia/log4j/ConditionTest.java
+++ b/log4j/src/test/java/com/tersesystems/echopraxia/log4j/ConditionTest.java
@@ -122,7 +122,7 @@ public class ConditionTest extends TestBase {
     JsonObject entry = getEntry();
     String message = entry.getString("message");
     assertThat(message).isEqualTo("Uncaught exception when running asyncLog");
-    String exceptionMessage = entry.getJsonObject("exception").getString("exception_message");
+    String exceptionMessage = entry.getJsonObject("thrown").getString("message");
     assertThat(exceptionMessage).isEqualTo("oh noes!");
   }
 
@@ -147,7 +147,7 @@ public class ConditionTest extends TestBase {
     JsonObject entry = getEntry();
     String message = entry.getString("message");
     assertThat(message).isEqualTo("Uncaught exception when running asyncLog");
-    String exceptionMessage = entry.getJsonObject("exception").getString("exception_message");
+    String exceptionMessage = entry.getJsonObject("thrown").getString("message");
     assertThat(exceptionMessage).isEqualTo("oh noes!");
   }
 }

--- a/log4j/src/test/java/com/tersesystems/echopraxia/log4j/ContextTest.java
+++ b/log4j/src/test/java/com/tersesystems/echopraxia/log4j/ContextTest.java
@@ -8,6 +8,8 @@ import com.tersesystems.echopraxia.Logger;
 import com.tersesystems.echopraxia.LoggerFactory;
 import javax.json.JsonArray;
 import javax.json.JsonObject;
+
+import com.tersesystems.echopraxia.core.CoreLoggerFactory;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.MarkerManager;
@@ -20,7 +22,7 @@ public class ContextTest extends TestBase {
   @Test
   void testMarkers() {
     Marker securityMarker = MarkerManager.getMarker("SECURITY");
-    final Log4JCoreLogger core = new Log4JCoreLogger((ExtendedLogger) LogManager.getLogger());
+    Log4JCoreLogger core = (Log4JCoreLogger) CoreLoggerFactory.getLogger(Logger.class.getName(), ContextTest.class);
     Logger<?> logger =
         LoggerFactory.getLogger(core.withMarker(securityMarker), Field.Builder.instance());
     logger.error("Message {}", fb -> fb.onlyString("field_name", "field_value"));
@@ -38,7 +40,7 @@ public class ContextTest extends TestBase {
     // AND we have a SECURITY marker in context
     // isTraceEnabled should return true even without an explicit marker.
     final Marker securityMarker = MarkerManager.getMarker("SECURITY");
-    final Log4JCoreLogger core = new Log4JCoreLogger((ExtendedLogger) LogManager.getLogger());
+    Log4JCoreLogger core = (Log4JCoreLogger) CoreLoggerFactory.getLogger(Logger.class.getName(), ContextTest.class);
     Logger<?> logger =
         LoggerFactory.getLogger(core.withMarker(securityMarker), Field.Builder.instance());
 

--- a/log4j/src/test/java/com/tersesystems/echopraxia/log4j/ContextTest.java
+++ b/log4j/src/test/java/com/tersesystems/echopraxia/log4j/ContextTest.java
@@ -6,15 +6,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.tersesystems.echopraxia.Field;
 import com.tersesystems.echopraxia.Logger;
 import com.tersesystems.echopraxia.LoggerFactory;
+import com.tersesystems.echopraxia.core.CoreLoggerFactory;
 import javax.json.JsonArray;
 import javax.json.JsonObject;
-
-import com.tersesystems.echopraxia.core.CoreLoggerFactory;
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.MarkerManager;
 import org.apache.logging.log4j.ThreadContext;
-import org.apache.logging.log4j.spi.ExtendedLogger;
 import org.junit.jupiter.api.Test;
 
 public class ContextTest extends TestBase {
@@ -22,7 +19,8 @@ public class ContextTest extends TestBase {
   @Test
   void testMarkers() {
     Marker securityMarker = MarkerManager.getMarker("SECURITY");
-    Log4JCoreLogger core = (Log4JCoreLogger) CoreLoggerFactory.getLogger(Logger.class.getName(), ContextTest.class);
+    Log4JCoreLogger core =
+        (Log4JCoreLogger) CoreLoggerFactory.getLogger(Logger.class.getName(), ContextTest.class);
     Logger<?> logger =
         LoggerFactory.getLogger(core.withMarker(securityMarker), Field.Builder.instance());
     logger.error("Message {}", fb -> fb.onlyString("field_name", "field_value"));
@@ -40,7 +38,8 @@ public class ContextTest extends TestBase {
     // AND we have a SECURITY marker in context
     // isTraceEnabled should return true even without an explicit marker.
     final Marker securityMarker = MarkerManager.getMarker("SECURITY");
-    Log4JCoreLogger core = (Log4JCoreLogger) CoreLoggerFactory.getLogger(Logger.class.getName(), ContextTest.class);
+    Log4JCoreLogger core =
+        (Log4JCoreLogger) CoreLoggerFactory.getLogger(Logger.class.getName(), ContextTest.class);
     Logger<?> logger =
         LoggerFactory.getLogger(core.withMarker(securityMarker), Field.Builder.instance());
 

--- a/log4j/src/test/java/com/tersesystems/echopraxia/log4j/LoggerTest.java
+++ b/log4j/src/test/java/com/tersesystems/echopraxia/log4j/LoggerTest.java
@@ -105,6 +105,19 @@ public class LoggerTest extends TestBase {
   }
 
   @Test
+  public void testLoggerLocation() {
+    Logger<?> logger = LoggerFactory.getLogger(getClass());
+    logger.info("Boring Message");
+
+    JsonObject entry = getEntry();
+    final JsonObject fields = entry.getJsonObject("source");
+    assertThat(fields.getString("class")).isEqualTo("com.tersesystems.echopraxia.log4j.LoggerTest");
+    assertThat(fields.getString("method")).isEqualTo("testLoggerLocation");
+    assertThat(fields.getString("file")).isEqualTo("LoggerTest.java");
+    assertThat(fields.getJsonNumber("line").intValue()).isEqualTo(110);
+  }
+
+  @Test
   public void testLoggerWithObjectField() {
     Logger<?> logger = LoggerFactory.getLogger(getClass());
     logger.info(

--- a/log4j/src/test/java/com/tersesystems/echopraxia/log4j/LoggerTest.java
+++ b/log4j/src/test/java/com/tersesystems/echopraxia/log4j/LoggerTest.java
@@ -199,7 +199,7 @@ public class LoggerTest extends TestBase {
     final String message = entry.getString("message");
     assertThat(message).isEqualTo("Message");
 
-    final JsonValue ex = entry.get("exception");
+    final JsonValue ex = entry.get("thrown");
     assertThat(ex).isNotNull();
   }
 
@@ -213,7 +213,7 @@ public class LoggerTest extends TestBase {
     final String message = entry.getString("message");
     assertThat(message).isEqualTo("Message exception=java.lang.RuntimeException: Some exception");
 
-    final JsonValue ex = entry.get("exception");
+    final JsonValue ex = entry.get("thrown");
     assertThat(ex).isNotNull();
   }
 

--- a/log4j/src/test/resources/log4j2.xml
+++ b/log4j/src/test/resources/log4j2.xml
@@ -6,7 +6,7 @@
 
     <Appenders>
         <Console name="Console" target="SYSTEM_OUT" follow="true">
-            <JsonTemplateLayout eventTemplateUri="classpath:LogstashJsonEventLayoutV1.json" locationInfoEnabled="true">
+            <JsonTemplateLayout eventTemplateUri="classpath:JsonLayout.json" locationInfoEnabled="true">
                 <EventTemplateAdditionalField
                         key="marker"
                         format="JSON"
@@ -26,7 +26,7 @@
             </JsonTemplateLayout>
         </Console>
         <List name="ListAppender">
-            <JsonTemplateLayout eventTemplateUri="classpath:LogstashJsonEventLayoutV1.json">
+            <JsonTemplateLayout eventTemplateUri="classpath:JsonLayout.json" locationInfoEnabled="true">
                 <EventTemplateAdditionalField
                         key="marker"
                         format="JSON"

--- a/logstash/src/jmh/java/com/tersesystems/echopraxia/logstash/CoreLoggerBenchmarks.java
+++ b/logstash/src/jmh/java/com/tersesystems/echopraxia/logstash/CoreLoggerBenchmarks.java
@@ -14,7 +14,8 @@ import org.openjdk.jmh.infra.Blackhole;
 @Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
 @Fork(1)
 public class CoreLoggerBenchmarks {
-  private static final CoreLogger logger = CoreLoggerFactory.getLogger(CoreLoggerBenchmarks.class.getName(), CoreLoggerBenchmarks.class);
+  private static final CoreLogger logger =
+      CoreLoggerFactory.getLogger(CoreLoggerBenchmarks.class.getName(), CoreLoggerBenchmarks.class);
   private static final Exception exception = new RuntimeException();
   private static final Field.Builder builder = Field.Builder.instance();
 

--- a/logstash/src/jmh/java/com/tersesystems/echopraxia/logstash/CoreLoggerBenchmarks.java
+++ b/logstash/src/jmh/java/com/tersesystems/echopraxia/logstash/CoreLoggerBenchmarks.java
@@ -14,7 +14,7 @@ import org.openjdk.jmh.infra.Blackhole;
 @Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
 @Fork(1)
 public class CoreLoggerBenchmarks {
-  private static final CoreLogger logger = CoreLoggerFactory.getLogger();
+  private static final CoreLogger logger = CoreLoggerFactory.getLogger(CoreLoggerBenchmarks.class.getName(), CoreLoggerBenchmarks.class);
   private static final Exception exception = new RuntimeException();
   private static final Field.Builder builder = Field.Builder.instance();
 

--- a/logstash/src/main/java/com/tersesystems/echopraxia/logstash/LogstashLoggerProvider.java
+++ b/logstash/src/main/java/com/tersesystems/echopraxia/logstash/LogstashLoggerProvider.java
@@ -21,11 +21,11 @@ public class LogstashLoggerProvider implements CoreLoggerProvider {
     addEchopraxiaPackages(loggerContext.getFrameworkPackages());
   }
 
-  public @NotNull CoreLogger getLogger(@NotNull Class<?> clazz) {
-    return getLogger(clazz.getName());
+  public @NotNull CoreLogger getLogger(@NotNull String fqcn, @NotNull Class<?> clazz) {
+    return getLogger(fqcn, clazz.getName());
   }
 
-  public @NotNull CoreLogger getLogger(@NotNull String name) {
+  public @NotNull CoreLogger getLogger(@NotNull String fqcn, @NotNull String name) {
     org.slf4j.Logger logger = loggerContext.getLogger(name);
     return new LogstashCoreLogger(logger);
   }

--- a/semantic/src/main/java/com/tersesystems/echopraxia/semantic/SemanticLoggerFactory.java
+++ b/semantic/src/main/java/com/tersesystems/echopraxia/semantic/SemanticLoggerFactory.java
@@ -28,6 +28,8 @@ import org.jetbrains.annotations.NotNull;
  */
 public class SemanticLoggerFactory {
 
+  static final String FQCN = SemanticLogger.class.getName();
+
   /**
    * Creates a semantic logger using a logger class and explicit field builder.
    *
@@ -46,7 +48,7 @@ public class SemanticLoggerFactory {
       Function<DataType, String> messageFunction,
       Function<DataType, Field.BuilderFunction<FB>> f,
       FB builder) {
-    CoreLogger coreLogger = CoreLoggerFactory.getLogger(clazz);
+    CoreLogger coreLogger = CoreLoggerFactory.getLogger(FQCN, clazz);
     return getLogger(coreLogger, dataTypeClass, messageFunction, f, builder);
   }
 
@@ -68,7 +70,7 @@ public class SemanticLoggerFactory {
       Function<DataType, String> messageFunction,
       Function<DataType, Field.BuilderFunction<FB>> f,
       FB builder) {
-    CoreLogger coreLogger = CoreLoggerFactory.getLogger(name);
+    CoreLogger coreLogger = CoreLoggerFactory.getLogger(FQCN, name);
     return getLogger(coreLogger, dataTypeClass, messageFunction, f, builder);
   }
 

--- a/semantic/src/test/java/com/tersesystems/echopraxia/semantic/SemanticLoggerTest.java
+++ b/semantic/src/test/java/com/tersesystems/echopraxia/semantic/SemanticLoggerTest.java
@@ -7,6 +7,7 @@ import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
 import com.tersesystems.echopraxia.Field;
+import com.tersesystems.echopraxia.core.Caller;
 import com.tersesystems.echopraxia.core.CoreLoggerFactory;
 import com.tersesystems.echopraxia.logstash.LogstashCoreLogger;
 import java.util.List;
@@ -46,7 +47,9 @@ public class SemanticLoggerTest {
 
   @Test
   public void testLoggerWithLogstashEscape() {
-    LogstashCoreLogger coreLogger = (LogstashCoreLogger) CoreLoggerFactory.getLogger();
+    LogstashCoreLogger coreLogger =
+        (LogstashCoreLogger)
+            CoreLoggerFactory.getLogger(SemanticLoggerFactory.FQCN, Caller.resolveClassName());
     SemanticLogger<Person> logger =
         SemanticLoggerFactory.getLogger(
             coreLogger.withMarkers(MarkerFactory.getMarker("SECURITY")),


### PR DESCRIPTION
Looks like it depends on `ExtendedLoggerWrapper`

https://stackoverflow.com/questions/35360887/java-logging-log4j-version2-x-show-the-method-of-an-end-client-caller-not-an

```java
package com.mycomp;

import java.io.Serializable;
import org.apache.logging.log4j.Level;
import org.apache.logging.log4j.LogManager;
import org.apache.logging.log4j.Logger;
import org.apache.logging.log4j.Marker;
import org.apache.logging.log4j.message.Message;
import org.apache.logging.log4j.message.MessageFactory;
import org.apache.logging.log4j.spi.AbstractLogger;
import org.apache.logging.log4j.spi.ExtendedLoggerWrapper;
import org.apache.logging.log4j.util.MessageSupplier;
import org.apache.logging.log4j.util.Supplier;

public final class MyLogger implements Serializable {
    private static final long serialVersionUID = 220370540087237L;
    private final ExtendedLoggerWrapper logger;

    private static final String FQCN = MyLogger.class.getName();
    private static final Level DEFCON1 = Level.forName("DEFCON1", 350);

    private MyLogger(final Logger logger) {
        this.logger = new ExtendedLoggerWrapper((AbstractLogger) logger, logger.getName(), logger.getMessageFactory());
    }

    /**
     * Returns a custom Logger with the name of the calling class.
     * 
     * @return The custom Logger for the calling class.
     */
    public static MyLogger create() {
        final Logger wrapped = LogManager.getLogger();
        return new MyLogger(wrapped);
    }

    public static MyLogger create(final String name) {
        final Logger wrapped = LogManager.getLogger(name);
        return new MyLogger(wrapped);
    }

    public void defcon1(final Marker marker, final Message msg) {
        logger.logIfEnabled(FQCN, DEFCON1, marker, msg, (Throwable) null);
    }
}
```