### PR TITLE
Condition should always be called after log level

### DIFF
--- a/logstash/src/main/java/com/tersesystems/echopraxia/logstash/LogstashCoreLogger.java
+++ b/logstash/src/main/java/com/tersesystems/echopraxia/logstash/LogstashCoreLogger.java
@@ -115,7 +115,7 @@ public class LogstashCoreLogger implements CoreLogger {
     if (condition == Condition.never()) {
       return false;
     }
-    Marker marker = context.convertMarkers();
+    Marker marker = context.getMarker();
     return logger.isEnabledFor(marker, convertLogbackLevel(level))
         && condition.test(level, context);
   }
@@ -128,14 +128,14 @@ public class LogstashCoreLogger implements CoreLogger {
     if (condition == Condition.never()) {
       return false;
     }
-    Marker marker = context.convertMarkers();
+    Marker marker = context.getMarker();
     return logger.isEnabledFor(marker, convertLogbackLevel(level))
         && this.condition.and(condition).test(level, context);
   }
 
   @Override
   public void log(@NotNull Level level, String message) {
-    Marker m = context.convertMarkers();
+    Marker m = context.getMarker();
     if (logger.isEnabledFor(m, convertLogbackLevel(level)) && condition.test(level, context)) {
       logger.log(m, fqcn, convertLevel(level), message, null, null);
     }
@@ -148,7 +148,7 @@ public class LogstashCoreLogger implements CoreLogger {
       Field.@NotNull BuilderFunction<FB> f,
       @NotNull FB builder) {
 
-    final Marker m = context.convertMarkers();
+    final Marker m = context.getMarker();
     if (logger.isEnabledFor(m, convertLogbackLevel(level)) && condition.test(level, context)) {
       final List<Field> args = f.apply(builder);
       final Object[] arguments = convertArguments(args);
@@ -158,7 +158,7 @@ public class LogstashCoreLogger implements CoreLogger {
 
   @Override
   public void log(@NotNull Level level, String message, @NotNull Throwable e) {
-    final Marker m = context.convertMarkers();
+    final Marker m = context.getMarker();
     if (logger.isEnabledFor(m, convertLogbackLevel(level)) && condition.test(level, context)) {
       logger.log(m, fqcn, convertLevel(level), message, null, e);
     }
@@ -166,7 +166,7 @@ public class LogstashCoreLogger implements CoreLogger {
 
   @Override
   public void log(@NotNull Level level, @NotNull Condition condition, String message) {
-    final Marker m = context.convertMarkers();
+    final Marker m = context.getMarker();
     if (logger.isEnabledFor(m, convertLogbackLevel(level))
         && this.condition.and(condition).test(level, context)) {
       logger.log(m, fqcn, convertLevel(level), message, null, null);
@@ -179,7 +179,7 @@ public class LogstashCoreLogger implements CoreLogger {
       @NotNull Condition condition,
       @Nullable String message,
       @NotNull Throwable e) {
-    final Marker m = context.convertMarkers();
+    final Marker m = context.getMarker();
     if (logger.isEnabledFor(m, convertLogbackLevel(level))
         && this.condition.and(condition).test(level, context)) {
       logger.log(m, fqcn, convertLevel(level), message, null, e);
@@ -193,7 +193,7 @@ public class LogstashCoreLogger implements CoreLogger {
       @Nullable String message,
       @NotNull Field.BuilderFunction<B> f,
       @NotNull B builder) {
-    final Marker m = context.convertMarkers();
+    final Marker m = context.getMarker();
     if (logger.isEnabledFor(m, convertLogbackLevel(level))
         && this.condition.and(condition).test(level, context)) {
       final List<Field> args = f.apply(builder);

--- a/logstash/src/main/java/com/tersesystems/echopraxia/logstash/LogstashCoreLogger.java
+++ b/logstash/src/main/java/com/tersesystems/echopraxia/logstash/LogstashCoreLogger.java
@@ -135,12 +135,10 @@ public class LogstashCoreLogger implements CoreLogger {
 
   @Override
   public void log(@NotNull Level level, String message) {
-    if (!condition.test(level, context)) {
-      return;
-    }
-
     Marker m = context.convertMarkers();
-    logger.log(m, fqcn, convertLevel(level), message, null, null);
+    if (logger.isEnabledFor(m, convertLogbackLevel(level)) && condition.test(level, context)) {
+      logger.log(m, fqcn, convertLevel(level), message, null, null);
+    }
   }
 
   @Override
@@ -149,32 +147,30 @@ public class LogstashCoreLogger implements CoreLogger {
       String message,
       Field.@NotNull BuilderFunction<FB> f,
       @NotNull FB builder) {
-    if (!condition.test(level, context)) {
-      return;
-    }
 
     final Marker m = context.convertMarkers();
-    final List<Field> args = f.apply(builder);
-    final Object[] arguments = convertArguments(args);
-    logger.log(m, fqcn, convertLevel(level), message, arguments, null);
+    if (logger.isEnabledFor(m, convertLogbackLevel(level)) && condition.test(level, context)) {
+      final List<Field> args = f.apply(builder);
+      final Object[] arguments = convertArguments(args);
+      logger.log(m, fqcn, convertLevel(level), message, arguments, null);
+    }
   }
 
   @Override
   public void log(@NotNull Level level, String message, @NotNull Throwable e) {
-    if (!condition.test(level, context)) {
-      return;
+    final Marker m = context.convertMarkers();
+    if (logger.isEnabledFor(m, convertLogbackLevel(level)) && condition.test(level, context)) {
+      logger.log(m, fqcn, convertLevel(level), message, null, e);
     }
-
-    Marker m = context.convertMarkers();
-    logger.log(m, fqcn, convertLevel(level), message, null, e);
   }
 
   @Override
   public void log(@NotNull Level level, @NotNull Condition condition, String message) {
-    if (!condition.test(level, context)) {
-      return;
+    final Marker m = context.convertMarkers();
+    if (logger.isEnabledFor(m, convertLogbackLevel(level))
+        && this.condition.and(condition).test(level, context)) {
+      logger.log(m, fqcn, convertLevel(level), message, null, null);
     }
-    log(level, message);
   }
 
   @Override
@@ -183,10 +179,11 @@ public class LogstashCoreLogger implements CoreLogger {
       @NotNull Condition condition,
       @Nullable String message,
       @NotNull Throwable e) {
-    if (!condition.test(level, context)) {
-      return;
+    final Marker m = context.convertMarkers();
+    if (logger.isEnabledFor(m, convertLogbackLevel(level))
+        && this.condition.and(condition).test(level, context)) {
+      logger.log(m, fqcn, convertLevel(level), message, null, e);
     }
-    log(level, message, e);
   }
 
   @Override
@@ -196,10 +193,13 @@ public class LogstashCoreLogger implements CoreLogger {
       @Nullable String message,
       @NotNull Field.BuilderFunction<B> f,
       @NotNull B builder) {
-    if (!condition.test(level, context)) {
-      return;
+    final Marker m = context.convertMarkers();
+    if (logger.isEnabledFor(m, convertLogbackLevel(level))
+        && this.condition.and(condition).test(level, context)) {
+      final List<Field> args = f.apply(builder);
+      final Object[] arguments = convertArguments(args);
+      logger.log(m, fqcn, convertLevel(level), message, arguments, null);
     }
-    log(level, message, f, builder);
   }
 
   @Override

--- a/logstash/src/main/java/com/tersesystems/echopraxia/logstash/LogstashLoggingContext.java
+++ b/logstash/src/main/java/com/tersesystems/echopraxia/logstash/LogstashLoggingContext.java
@@ -98,7 +98,7 @@ public class LogstashLoggingContext implements LoggingContext {
   }
 
   // Convert markers explicitly.
-  org.slf4j.Marker convertMarkers() {
+  org.slf4j.Marker getMarker() {
     final List<Field> fields = getFields();
     final List<Marker> markers = getMarkers();
 


### PR DESCRIPTION
Logging level should always be checked first because a condition could be expensive.  Even compiled, a tweakflow script is 100ns vs 3 ns for a loglevel check, so it's worth running checks multiple times.