### PR TITLE
Add getName to Logger

### DIFF
--- a/api/src/main/java/com/tersesystems/echopraxia/AsyncLogger.java
+++ b/api/src/main/java/com/tersesystems/echopraxia/AsyncLogger.java
@@ -35,6 +35,11 @@ public class AsyncLogger<FB extends Field.Builder> implements LoggerLike<FB, Asy
     this.fieldBuilder = fieldBuilder;
   }
 
+  @Override
+  public @NotNull String getName() {
+    return core.getName();
+  }
+
   /** @return the internal core logger. */
   @Override
   @NotNull

--- a/api/src/main/java/com/tersesystems/echopraxia/Logger.java
+++ b/api/src/main/java/com/tersesystems/echopraxia/Logger.java
@@ -43,6 +43,11 @@ public class Logger<FB extends Field.Builder> implements LoggerLike<FB, Logger<F
     this.fieldBuilder = fieldBuilder;
   }
 
+  @Override
+  public @NotNull String getName() {
+    return core.getName();
+  }
+
   /** @return the internal core logger. */
   @Override
   @NotNull

--- a/api/src/main/java/com/tersesystems/echopraxia/LoggerLike.java
+++ b/api/src/main/java/com/tersesystems/echopraxia/LoggerLike.java
@@ -13,6 +13,9 @@ import org.jetbrains.annotations.Nullable;
 public interface LoggerLike<FB extends Field.Builder, SELF extends LoggerLike<FB, SELF>> {
 
   @NotNull
+  String getName();
+
+  @NotNull
   CoreLogger core();
 
   @NotNull

--- a/api/src/main/java/com/tersesystems/echopraxia/core/CoreLogger.java
+++ b/api/src/main/java/com/tersesystems/echopraxia/core/CoreLogger.java
@@ -24,6 +24,14 @@ import org.jetbrains.annotations.Nullable;
 public interface CoreLogger {
 
   /**
+   * The name of the logger.
+   *
+   * @return logger name.
+   */
+  @NotNull
+  String getName();
+
+  /**
    * Is the logger instance enabled for the given level and logger conditions?
    *
    * @param level the level to log at.

--- a/fluent/src/main/java/com/tersesystems/echopraxia/fluent/FluentLogger.java
+++ b/fluent/src/main/java/com/tersesystems/echopraxia/fluent/FluentLogger.java
@@ -29,6 +29,11 @@ public class FluentLogger<FB extends Field.Builder> {
   }
 
   @NotNull
+  String getName() {
+    return core.getName();
+  }
+
+  @NotNull
   public CoreLogger core() {
     return core;
   }

--- a/log4j/src/main/java/com/tersesystems/echopraxia/log4j/Log4JCoreLogger.java
+++ b/log4j/src/main/java/com/tersesystems/echopraxia/log4j/Log4JCoreLogger.java
@@ -61,8 +61,15 @@ public class Log4JCoreLogger implements CoreLogger {
     this.executor = executor;
   }
 
+  @NotNull
   public Logger logger() {
     return this.logger;
+  }
+
+  @Override
+  @NotNull
+  public String getName() {
+    return logger.getName();
   }
 
   @Override

--- a/logstash/src/main/java/com/tersesystems/echopraxia/logstash/LogstashCoreLogger.java
+++ b/logstash/src/main/java/com/tersesystems/echopraxia/logstash/LogstashCoreLogger.java
@@ -58,6 +58,12 @@ public class LogstashCoreLogger implements CoreLogger {
     return logger;
   }
 
+  @Override
+  @NotNull
+  public String getName() {
+    return logger.getName();
+  }
+
   /**
    * Returns the condition.
    *

--- a/semantic/src/main/java/com/tersesystems/echopraxia/semantic/SemanticLogger.java
+++ b/semantic/src/main/java/com/tersesystems/echopraxia/semantic/SemanticLogger.java
@@ -18,6 +18,9 @@ import org.jetbrains.annotations.NotNull;
 public interface SemanticLogger<DataType> {
 
   @NotNull
+  String getName();
+
+  @NotNull
   CoreLogger core();
 
   boolean isErrorEnabled();

--- a/semantic/src/main/java/com/tersesystems/echopraxia/semantic/SemanticLoggerFactory.java
+++ b/semantic/src/main/java/com/tersesystems/echopraxia/semantic/SemanticLoggerFactory.java
@@ -191,6 +191,11 @@ public class SemanticLoggerFactory {
     }
 
     @Override
+    public @NotNull String getName() {
+      return core.getName();
+    }
+
+    @Override
     public @NotNull CoreLogger core() {
       return core;
     }


### PR DESCRIPTION
All logging frameworks implement loggers with names, even if it's "root"