### PR TITLE
Reorder level enum

### DIFF
--- a/api/src/main/java/com/tersesystems/echopraxia/Level.java
+++ b/api/src/main/java/com/tersesystems/echopraxia/Level.java
@@ -7,9 +7,27 @@ package com.tersesystems.echopraxia;
  * exercise caution when looking at cardinal/numeric values because they're all different.
  */
 public enum Level {
-  ERROR,
-  WARN,
-  INFO,
-  DEBUG,
-  TRACE
+
+  // Order is significant, and compareTo uses ordinal values internally.
+  TRACE, // 0
+  DEBUG, // 1
+  INFO,  // 2
+  WARN,  // 3
+  ERROR; // 4
+
+  public boolean isGreater(Level r) {
+    return compareTo(r) > 0;
+  }
+
+  public boolean isGreaterOrEqual(Level r) {
+    return compareTo(r) >= 0;
+  }
+
+  public boolean isLess(Level r) {
+    return compareTo(r) < 0;
+  }
+
+  public boolean isLessOrEqual(Level r) {
+    return compareTo(r) <= 0;
+  }
 }

--- a/api/src/main/java/com/tersesystems/echopraxia/Level.java
+++ b/api/src/main/java/com/tersesystems/echopraxia/Level.java
@@ -30,4 +30,8 @@ public enum Level {
   public boolean isLessOrEqual(Level r) {
     return compareTo(r) <= 0;
   }
+
+  public boolean isEqual(Level r) {
+    return equals(r);
+  }
 }

--- a/api/src/test/java/com/tersesystems/echopraxia/LevelTests.java
+++ b/api/src/test/java/com/tersesystems/echopraxia/LevelTests.java
@@ -1,0 +1,53 @@
+package com.tersesystems.echopraxia;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class LevelTests {
+
+  @Test
+  public void testGreaterThan() {
+    assertThat(Level.INFO.isGreater(Level.DEBUG)).isTrue();
+  }
+
+  @Test
+  public void testIsNotGreaterThan() {
+    assertThat(Level.INFO.isGreater(Level.ERROR)).isFalse();
+  }
+  
+  @Test
+  public void testIsGreaterThanOrEqual() {
+    assertThat(Level.INFO.isGreaterOrEqual(Level.DEBUG)).isTrue();
+  }
+
+  @Test
+  public void testIsGreaterThanOrEqualEquality() {
+    assertThat(Level.ERROR.isGreaterOrEqual(Level.ERROR)).isTrue();
+  }
+
+  @Test
+  public void testIsLess() {
+    assertThat(Level.DEBUG.isLess(Level.INFO)).isTrue();
+  }
+
+  @Test
+  public void testIsNotLess() {
+    assertThat(Level.INFO.isLess(Level.DEBUG)).isFalse();
+  }
+
+  @Test
+  public void testIsLessOrEqual() {
+    assertThat(Level.TRACE.isLessOrEqual(Level.DEBUG)).isTrue();
+  }
+
+  @Test
+  public void testIsLessOrEqualEquality() {
+    assertThat(Level.TRACE.isLessOrEqual(Level.TRACE)).isTrue();
+  }
+
+  @Test
+  public void testIsEqual() {
+    assertThat(Level.TRACE.isEqual(Level.TRACE)).isTrue();
+  }
+}


### PR DESCRIPTION
Should be able use conditions with `condition.greaterThanOrEqual(DEBUG)`

Needs tests, also note in release