### PR TITLE
scripting benchmarks using find string

### DIFF
--- a/api/src/main/java/com/tersesystems/echopraxia/Internals.java
+++ b/api/src/main/java/com/tersesystems/echopraxia/Internals.java
@@ -4,7 +4,7 @@ import java.util.List;
 import java.util.concurrent.atomic.LongAdder;
 import org.jetbrains.annotations.NotNull;
 
-// Some package private constants
+/** Internals class, super not public. */
 class Internals {
 
   public static final String ECHOPRAXIA_UNKNOWN = "echopraxia-unknown-";

--- a/logstash/src/jmh/java/com/tersesystems/echopraxia/logstash/JsonPathBenchmarks.java
+++ b/logstash/src/jmh/java/com/tersesystems/echopraxia/logstash/JsonPathBenchmarks.java
@@ -2,11 +2,8 @@ package com.tersesystems.echopraxia.logstash;
 
 import com.tersesystems.echopraxia.Condition;
 import com.tersesystems.echopraxia.Field;
-import com.tersesystems.echopraxia.Level;
 import com.tersesystems.echopraxia.LoggingContext;
 import com.tersesystems.echopraxia.ValueField;
-import com.tersesystems.echopraxia.logstash.LogstashLoggingContext;
-
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.infra.Blackhole;
@@ -18,17 +15,18 @@ import org.openjdk.jmh.infra.Blackhole;
 @Fork(1)
 public class JsonPathBenchmarks {
 
-  private static final Condition streamCondition = Condition.valueMatch("some_field", f -> f.raw().equals("testing"));
-  private static final Condition pathCondition = new Condition() {
-    @Override
-    public boolean test(com.tersesystems.echopraxia.Level level, LoggingContext context) {
-      return context.findString("$.some_field").filter(f -> f.equals("testing")).isPresent();
-    }
-  };
+  private static final Condition streamCondition =
+      Condition.valueMatch("some_field", f -> f.raw().equals("testing"));
+  private static final Condition pathCondition =
+      new Condition() {
+        @Override
+        public boolean test(com.tersesystems.echopraxia.Level level, LoggingContext context) {
+          return context.findString("$.some_field").filter(f -> f.equals("testing")).isPresent();
+        }
+      };
 
-  private static final LoggingContext passContext = LogstashLoggingContext.create(
-    ValueField.create("some_field", Field.Value.string("testing"))
-  );
+  private static final LoggingContext passContext =
+      LogstashLoggingContext.create(ValueField.create("some_field", Field.Value.string("testing")));
 
   private static final LoggingContext failContext = LogstashLoggingContext.empty();
 
@@ -51,5 +49,4 @@ public class JsonPathBenchmarks {
   public void testPathConditionFail(Blackhole blackhole) {
     blackhole.consume(pathCondition.test(com.tersesystems.echopraxia.Level.INFO, failContext));
   }
-
 }

--- a/logstash/src/jmh/java/com/tersesystems/echopraxia/logstash/JsonPathBenchmarks.java
+++ b/logstash/src/jmh/java/com/tersesystems/echopraxia/logstash/JsonPathBenchmarks.java
@@ -1,0 +1,55 @@
+package com.tersesystems.echopraxia.logstash;
+
+import com.tersesystems.echopraxia.Condition;
+import com.tersesystems.echopraxia.Field;
+import com.tersesystems.echopraxia.Level;
+import com.tersesystems.echopraxia.LoggingContext;
+import com.tersesystems.echopraxia.ValueField;
+import com.tersesystems.echopraxia.logstash.LogstashLoggingContext;
+
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(1)
+public class JsonPathBenchmarks {
+
+  private static final Condition streamCondition = Condition.valueMatch("some_field", f -> f.raw().equals("testing"));
+  private static final Condition pathCondition = new Condition() {
+    @Override
+    public boolean test(com.tersesystems.echopraxia.Level level, LoggingContext context) {
+      return context.findString("$.some_field").filter(f -> f.equals("testing")).isPresent();
+    }
+  };
+
+  private static final LoggingContext passContext = LogstashLoggingContext.create(
+    ValueField.create("some_field", Field.Value.string("testing"))
+  );
+
+  private static final LoggingContext failContext = LogstashLoggingContext.empty();
+
+  @Benchmark
+  public void testStreamConditionPass(Blackhole blackhole) {
+    blackhole.consume(streamCondition.test(com.tersesystems.echopraxia.Level.INFO, passContext));
+  }
+
+  @Benchmark
+  public void testStreamConditionFail(Blackhole blackhole) {
+    blackhole.consume(streamCondition.test(com.tersesystems.echopraxia.Level.INFO, failContext));
+  }
+
+  @Benchmark
+  public void testPathConditionPass(Blackhole blackhole) {
+    blackhole.consume(pathCondition.test(com.tersesystems.echopraxia.Level.INFO, passContext));
+  }
+
+  @Benchmark
+  public void testPathConditionFail(Blackhole blackhole) {
+    blackhole.consume(pathCondition.test(com.tersesystems.echopraxia.Level.INFO, failContext));
+  }
+
+}

--- a/logstash/src/main/java/com/tersesystems/echopraxia/logstash/LogstashLoggingContext.java
+++ b/logstash/src/main/java/com/tersesystems/echopraxia/logstash/LogstashLoggingContext.java
@@ -4,6 +4,7 @@ import com.tersesystems.echopraxia.Field;
 import com.tersesystems.echopraxia.support.AbstractLoggingContext;
 import com.tersesystems.echopraxia.support.Utilities;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Supplier;
@@ -32,6 +33,15 @@ public class LogstashLoggingContext extends AbstractLoggingContext {
     this.fieldsSupplier = Utilities.memoize(f);
     this.markersSupplier = m;
   }
+
+  public static LogstashLoggingContext create(List<Field> fields) {
+    return new LogstashLoggingContext(() -> fields, Collections::emptyList);
+  }
+
+  public static LogstashLoggingContext create(Field field) {
+    return new LogstashLoggingContext(() -> Collections.singletonList(field), Collections::emptyList);
+  }
+
 
   public static LogstashLoggingContext empty() {
     return EMPTY;

--- a/logstash/src/main/java/com/tersesystems/echopraxia/logstash/LogstashLoggingContext.java
+++ b/logstash/src/main/java/com/tersesystems/echopraxia/logstash/LogstashLoggingContext.java
@@ -4,7 +4,6 @@ import com.tersesystems.echopraxia.Field;
 import com.tersesystems.echopraxia.support.AbstractLoggingContext;
 import com.tersesystems.echopraxia.support.Utilities;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Supplier;
@@ -39,9 +38,9 @@ public class LogstashLoggingContext extends AbstractLoggingContext {
   }
 
   public static LogstashLoggingContext create(Field field) {
-    return new LogstashLoggingContext(() -> Collections.singletonList(field), Collections::emptyList);
+    return new LogstashLoggingContext(
+        () -> Collections.singletonList(field), Collections::emptyList);
   }
-
 
   public static LogstashLoggingContext empty() {
     return EMPTY;

--- a/scripting/src/jmh/java/com/tersesystems/echopraxia/scripting/ScriptingBenchmarks.java
+++ b/scripting/src/jmh/java/com/tersesystems/echopraxia/scripting/ScriptingBenchmarks.java
@@ -1,6 +1,6 @@
 package com.tersesystems.echopraxia.scripting;
 
-import com.tersesystems.echopraxia.Condition;
+import com.tersesystems.echopraxia.*;
 import com.tersesystems.echopraxia.Level;
 import com.tersesystems.echopraxia.logstash.LogstashLoggingContext;
 import java.nio.file.Path;
@@ -20,12 +20,13 @@ public class ScriptingBenchmarks {
   private static final Path watchedDir = Paths.get("src/jmh/tweakflow");
 
   public static String buildScript() {
-    StringBuilder b = new StringBuilder("");
-    b.append("library echopraxia {");
-    b.append("  function evaluate: (string level, dict fields) ->");
-    b.append("    level == \"INFO\";");
-    b.append("}");
-    return b.toString();
+    return "library echopraxia {\n" +
+      "  function evaluate: (string level, dict ctx) ->\n" +
+      "    let {\n" +
+      "      find_number: ctx[:find_number];\n" +
+      "    }\n" +
+      "    find_number(\"$.some_field\") == 1;\n" +
+      "}\n";
   }
 
   private static final Condition fileCondition =
@@ -42,39 +43,39 @@ public class ScriptingBenchmarks {
 
   private static final Condition watchedCondition = ScriptCondition.create(false, watchedScript);
 
+  private static final LoggingContext passContext = LogstashLoggingContext.create(
+    ValueField.create("some_field", Field.Value.number(1))
+  );
+
+  private static final LoggingContext failContext = LogstashLoggingContext.empty();
+
   @Benchmark
   public void testFileConditionMatch(Blackhole blackhole) {
-    // ScriptingBenchmarks.testFileConditionMatch     avgt    5  127.251 ± 0.816  ns/op
-    blackhole.consume(fileCondition.test(Level.INFO, LogstashLoggingContext.empty()));
+    blackhole.consume(fileCondition.test(Level.INFO, passContext));
   }
 
   @Benchmark
   public void testStringConditionMatch(Blackhole blackhole) {
-    // ScriptingBenchmarks.testStringConditionMatch   avgt    5  122.905 ± 3.440  ns/op
-    blackhole.consume(stringCondition.test(Level.INFO, LogstashLoggingContext.empty()));
+    blackhole.consume(stringCondition.test(Level.INFO, passContext));
   }
 
   @Benchmark
   public void testFileConditionFail(Blackhole blackhole) {
-    // ScriptingBenchmarks.testFileConditionFail      avgt    5  112.629 ± 2.951  ns/op
-    blackhole.consume(fileCondition.test(Level.DEBUG, LogstashLoggingContext.empty()));
+    blackhole.consume(fileCondition.test(Level.INFO, failContext));
   }
 
   @Benchmark
   public void testStringConditionFail(Blackhole blackhole) {
-    // ScriptingBenchmarks.testStringConditionFail    avgt    5  118.323 ± 4.296  ns/op
-    blackhole.consume(stringCondition.test(Level.DEBUG, LogstashLoggingContext.empty()));
+    blackhole.consume(stringCondition.test(Level.INFO, failContext));
   }
 
   @Benchmark
   public void testWatchedConditionMatch(Blackhole blackhole) {
-    // ScriptingBenchmarks.testWatchedConditionMatch  avgt    5  134.601 ± 2.325  ns/op
-    blackhole.consume(watchedCondition.test(Level.INFO, LogstashLoggingContext.empty()));
+    blackhole.consume(watchedCondition.test(Level.INFO, passContext));
   }
 
   @Benchmark
   public void testWatchedConditionFail(Blackhole blackhole) {
-    // ScriptingBenchmarks.testWatchedConditionFail   avgt    5  125.652 ± 5.286  ns/op
-    blackhole.consume(watchedCondition.test(Level.DEBUG, LogstashLoggingContext.empty()));
+    blackhole.consume(watchedCondition.test(Level.DEBUG, failContext));
   }
 }

--- a/scripting/src/jmh/java/com/tersesystems/echopraxia/scripting/ScriptingBenchmarks.java
+++ b/scripting/src/jmh/java/com/tersesystems/echopraxia/scripting/ScriptingBenchmarks.java
@@ -20,13 +20,13 @@ public class ScriptingBenchmarks {
   private static final Path watchedDir = Paths.get("src/jmh/tweakflow");
 
   public static String buildScript() {
-    return "library echopraxia {\n" +
-      "  function evaluate: (string level, dict ctx) ->\n" +
-      "    let {\n" +
-      "      find_number: ctx[:find_number];\n" +
-      "    }\n" +
-      "    find_number(\"$.some_field\") == 1;\n" +
-      "}\n";
+    return "library echopraxia {\n"
+        + "  function evaluate: (string level, dict ctx) ->\n"
+        + "    let {\n"
+        + "      find_number: ctx[:find_number];\n"
+        + "    }\n"
+        + "    find_number(\"$.some_field\") == 1;\n"
+        + "}\n";
   }
 
   private static final Condition fileCondition =
@@ -43,9 +43,8 @@ public class ScriptingBenchmarks {
 
   private static final Condition watchedCondition = ScriptCondition.create(false, watchedScript);
 
-  private static final LoggingContext passContext = LogstashLoggingContext.create(
-    ValueField.create("some_field", Field.Value.number(1))
-  );
+  private static final LoggingContext passContext =
+      LogstashLoggingContext.create(ValueField.create("some_field", Field.Value.number(1)));
 
   private static final LoggingContext failContext = LogstashLoggingContext.empty();
 

--- a/scripting/src/jmh/tweakflow/condition.tf
+++ b/scripting/src/jmh/tweakflow/condition.tf
@@ -1,4 +1,7 @@
 library echopraxia {
-  function evaluate: (string level, dict fields) ->
-     level == "INFO";
+  function evaluate: (string level, dict ctx) ->
+    let {
+      find_number: ctx[:find_number];
+    }
+    find_number("$.some_field") == 1;
 }


### PR DESCRIPTION
Something is causing findString to be slow when used through the scripting language:

```
Benchmark                                      Mode  Cnt     Score     Error  Units
ScriptingBenchmarks.testFileConditionFail      avgt    5  4379.959 ± 579.831  ns/op
ScriptingBenchmarks.testFileConditionMatch     avgt    5  4610.075 ± 147.281  ns/op
ScriptingBenchmarks.testStringConditionFail    avgt    5  4649.784 ±  87.629  ns/op
ScriptingBenchmarks.testStringConditionMatch   avgt    5  4262.437 ± 191.742  ns/op
ScriptingBenchmarks.testWatchedConditionFail   avgt    5  5242.896 ±  93.665  ns/op
ScriptingBenchmarks.testWatchedConditionMatch  avgt    5  4700.055 ±  87.745  ns/op
```

Running the findString directly gives much better benchmarks, around 480 ns or so...

```
JsonPathBenchmarks.testPathConditionFail          avgt    5  474.741 ± 25.194  ns/op
JsonPathBenchmarks.testPathConditionPass          avgt    5  480.219 ± 93.595  ns/op
JsonPathBenchmarks.testStreamConditionFail        avgt    5   65.068 ±  6.154  ns/op
JsonPathBenchmarks.testStreamConditionPass        avgt    5   70.406 ±  1.922  ns/op
```