### PR TITLE
Move out return value

### DIFF
--- a/api/src/main/java/com/tersesystems/echopraxia/api/AbstractLoggerSupport.java
+++ b/api/src/main/java/com/tersesystems/echopraxia/api/AbstractLoggerSupport.java
@@ -1,6 +1,5 @@
 package com.tersesystems.echopraxia.api;
 
-import java.util.List;
 import java.util.function.Function;
 import org.jetbrains.annotations.NotNull;
 
@@ -10,7 +9,8 @@ import org.jetbrains.annotations.NotNull;
  * @param <SELF> the actual type of the logger.
  * @param <FB> the field builder.
  */
-public abstract class AbstractLoggerSupport<SELF extends AbstractLoggerSupport<SELF, FB>, FB>
+public abstract class AbstractLoggerSupport<
+        SELF extends AbstractLoggerSupport<SELF, FB, RET>, FB, RET>
     implements DefaultMethodsSupport<FB> {
 
   protected final CoreLogger core;
@@ -54,7 +54,7 @@ public abstract class AbstractLoggerSupport<SELF extends AbstractLoggerSupport<S
   }
 
   @NotNull
-  public SELF withFields(@NotNull Function<FB, List<Field>> f) {
+  public SELF withFields(@NotNull Function<FB, RET> f) {
     return newLogger(core().withFields(f, fieldBuilder));
   }
 

--- a/api/src/main/java/com/tersesystems/echopraxia/api/CoreLogger.java
+++ b/api/src/main/java/com/tersesystems/echopraxia/api/CoreLogger.java
@@ -149,10 +149,10 @@ public interface CoreLogger {
    * @param builder the field builder
    * @param <FB> the type of field builder.
    */
-  <FB> void log(
+  <FB, RET> void log(
       @NotNull Level level,
       @Nullable String message,
-      @NotNull Function<FB, List<Field>> f,
+      @NotNull Function<FB, RET> f,
       @NotNull FB builder);
 
   /**
@@ -174,11 +174,11 @@ public interface CoreLogger {
    * @param builder the field builder
    * @param <FB> the type of field builder.
    */
-  <FB> void log(
+  <FB, RET> void log(
       @NotNull Level level,
       @NotNull Condition condition,
       @Nullable String message,
-      @NotNull Function<FB, List<Field>> f,
+      @NotNull Function<FB, RET> f,
       @NotNull FB builder);
 
   /**

--- a/api/src/main/java/com/tersesystems/echopraxia/api/CoreLogger.java
+++ b/api/src/main/java/com/tersesystems/echopraxia/api/CoreLogger.java
@@ -61,7 +61,7 @@ public interface CoreLogger {
    * @return the core logger with given context fields applied.
    */
   @NotNull
-  <B> CoreLogger withFields(@NotNull Function<B, List<Field>> f, @NotNull B builder);
+  <B, RET> CoreLogger withFields(@NotNull Function<B, RET> f, @NotNull B builder);
 
   /**
    * Pulls fields from thread context into logger context, if any exist and the implementation
@@ -189,8 +189,8 @@ public interface CoreLogger {
    * @param consumer the consumer of the logger handle
    * @param builder the field builder.
    */
-  <FB> void asyncLog(
-      @NotNull Level level, @NotNull Consumer<LoggerHandle<FB>> consumer, @NotNull FB builder);
+  <FB, RET> void asyncLog(
+      @NotNull Level level, @NotNull Consumer<LoggerHandle<FB, RET>> consumer, @NotNull FB builder);
 
   /**
    * Logs a statement asynchronously using an executor and the given condition.
@@ -201,9 +201,9 @@ public interface CoreLogger {
    * @param consumer the consumer of the logger handle
    * @param builder the field builder.
    */
-  <FB> void asyncLog(
+  <FB, RET> void asyncLog(
       @NotNull Level level,
       @NotNull Condition condition,
-      @NotNull Consumer<LoggerHandle<FB>> consumer,
+      @NotNull Consumer<LoggerHandle<FB, RET>> consumer,
       @NotNull FB builder);
 }

--- a/api/src/main/java/com/tersesystems/echopraxia/api/FieldConversion.java
+++ b/api/src/main/java/com/tersesystems/echopraxia/api/FieldConversion.java
@@ -1,0 +1,32 @@
+package com.tersesystems.echopraxia.api;
+
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+import org.jetbrains.annotations.Nullable;
+
+public class FieldConversion implements Function<Object, List<Field>> {
+  @SuppressWarnings("unchecked")
+  public List<Field> apply(@Nullable Object input) {
+    if (input instanceof List) {
+      return (List<Field>) input;
+    } else if (input instanceof Field) {
+      return Collections.singletonList((Field) input);
+    } else if (input instanceof Iterable) {
+      final Spliterator<Field> iterator = ((Iterable<Field>) input).spliterator();
+      return StreamSupport.stream(iterator, false).collect(Collectors.toList());
+    } else if (input instanceof Iterator) {
+      final Iterator<Field> iterator = (Iterator<Field>) input;
+      final Spliterator<Field> fieldSpliterator = Spliterators.spliteratorUnknownSize(iterator, 0);
+      return StreamSupport.stream(fieldSpliterator, false).collect(Collectors.toList());
+    } else if (input instanceof Stream) {
+      return ((Stream<Field>) input).collect(Collectors.toList());
+    } else if (input instanceof Field[]) {
+      return Arrays.asList((Field[]) input);
+    } else {
+      return Collections.emptyList();
+    }
+  }
+}

--- a/api/src/main/java/com/tersesystems/echopraxia/api/LoggerHandle.java
+++ b/api/src/main/java/com/tersesystems/echopraxia/api/LoggerHandle.java
@@ -1,12 +1,11 @@
 package com.tersesystems.echopraxia.api;
 
-import java.util.List;
 import java.util.function.Function;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 /** The LoggerHandle class is used as a handle to a logger at a specific level. */
-public interface LoggerHandle<FB> {
+public interface LoggerHandle<FB, RET> {
 
   /**
    * Logs using a message.
@@ -21,5 +20,5 @@ public interface LoggerHandle<FB> {
    * @param message the message template.
    * @param f the field builder function.
    */
-  void log(@Nullable String message, @NotNull Function<FB, List<Field>> f);
+  void log(@Nullable String message, @NotNull Function<FB, RET> f);
 }

--- a/api/src/test/java/com/tersesystems/echopraxia/fake/FakeCoreLogger.java
+++ b/api/src/test/java/com/tersesystems/echopraxia/fake/FakeCoreLogger.java
@@ -71,9 +71,9 @@ public class FakeCoreLogger implements CoreLogger {
   }
 
   @Override
-  public @NotNull <FB> CoreLogger withFields(
-      @NotNull Function<FB, List<Field>> f, @NotNull FB builder) {
-    FakeLoggingContext newContext = new FakeLoggingContext(() -> f.apply(builder));
+  public @NotNull <FB, RET> CoreLogger withFields(
+      @NotNull Function<FB, RET> f, @NotNull FB builder) {
+    FakeLoggingContext newContext = new FakeLoggingContext(() -> (List<Field>) f.apply(builder));
     return new FakeCoreLogger(
         fqcn, context.and(newContext), this.condition.and(condition), executor, tlsSupplier);
   }
@@ -160,13 +160,15 @@ public class FakeCoreLogger implements CoreLogger {
   // -----------------------------------------------------------------------
 
   @Override
-  public <FB> void asyncLog(
-      @NotNull Level level, @NotNull Consumer<LoggerHandle<FB>> consumer, @NotNull FB builder) {}
+  public <FB, RET> void asyncLog(
+      @NotNull Level level,
+      @NotNull Consumer<LoggerHandle<FB, RET>> consumer,
+      @NotNull FB builder) {}
 
   @Override
-  public <FB> void asyncLog(
+  public <FB, RET> void asyncLog(
       @NotNull Level level,
       @NotNull Condition condition,
-      @NotNull Consumer<LoggerHandle<FB>> consumer,
+      @NotNull Consumer<LoggerHandle<FB, RET>> consumer,
       @NotNull FB builder) {}
 }

--- a/api/src/test/java/com/tersesystems/echopraxia/fake/FakeCoreLogger.java
+++ b/api/src/test/java/com/tersesystems/echopraxia/fake/FakeCoreLogger.java
@@ -115,13 +115,13 @@ public class FakeCoreLogger implements CoreLogger {
   }
 
   @Override
-  public <FB> void log(
+  public <FB, RET> void log(
       @NotNull Level level,
       @Nullable String message,
-      @NotNull Function<FB, List<Field>> f,
+      @NotNull Function<FB, RET> f,
       @NotNull FB builder) {
-    List<Field> args = f.apply(builder);
-    FakeLoggingContext argContext = new FakeLoggingContext(() -> args);
+    Object args = f.apply(builder);
+    FakeLoggingContext argContext = new FakeLoggingContext(() -> (List<Field>) args);
     if (isEnabledFor(level) && this.condition.test(level, context.and(argContext))) {
       List<Field> fields = context.getFields();
       System.out.printf("" + message + " level %s fields %s args %s\n", level, fields, args);
@@ -137,16 +137,16 @@ public class FakeCoreLogger implements CoreLogger {
   }
 
   @Override
-  public <FB> void log(
+  public <FB, RET> void log(
       @NotNull Level level,
       @NotNull Condition condition,
       @Nullable String message,
-      @NotNull Function<FB, List<Field>> f,
+      @NotNull Function<FB, RET> f,
       @NotNull FB builder) {
     // When passing a condition through with explicit arguments, we pull the args and make
     // them available through context.
     List<Field> fields = context.getFields();
-    List<Field> args = f.apply(builder);
+    List<Field> args = (List<Field>) f.apply(builder);
     FakeLoggingContext argContext = new FakeLoggingContext(() -> args);
     if (isEnabledFor(level) && this.condition.and(condition).test(level, context.and(argContext))) {
       System.out.printf("" + message + " level %s fields %s args %s\n", level, fields, args);

--- a/async/src/main/java/com/tersesystems/echopraxia/async/AsyncLogger.java
+++ b/async/src/main/java/com/tersesystems/echopraxia/async/AsyncLogger.java
@@ -1,7 +1,6 @@
 package com.tersesystems.echopraxia.async;
 
 import com.tersesystems.echopraxia.api.*;
-import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -20,8 +19,9 @@ import org.jetbrains.annotations.Nullable;
  *
  * @param <FB> the field builder type
  */
-public class AsyncLogger<FB extends FieldBuilder> extends AbstractLoggerSupport<AsyncLogger<FB>, FB>
-    implements DefaultAsyncLoggerMethods<FB> {
+public class AsyncLogger<FB extends FieldBuilder>
+    extends AbstractLoggerSupport<AsyncLogger<FB>, FB, Object>
+    implements DefaultAsyncLoggerMethods<FB, Object> {
 
   protected AsyncLogger(@NotNull CoreLogger core, @NotNull FB fieldBuilder) {
     super(core, fieldBuilder, AsyncLogger.class);
@@ -119,7 +119,7 @@ public class AsyncLogger<FB extends FieldBuilder> extends AbstractLoggerSupport<
       return this;
     }
 
-    public void trace(@NotNull Consumer<LoggerHandle<FB>> consumer) {}
+    public void trace(@NotNull Consumer<LoggerHandle<FB, Object>> consumer) {}
 
     /**
      * Logs using a condition and a logger handle at TRACE level.
@@ -127,13 +127,13 @@ public class AsyncLogger<FB extends FieldBuilder> extends AbstractLoggerSupport<
      * @param c the condition
      * @param consumer the consumer of the logger handle.
      */
-    public void trace(@NotNull Condition c, @NotNull Consumer<LoggerHandle<FB>> consumer) {}
+    public void trace(@NotNull Condition c, @NotNull Consumer<LoggerHandle<FB, Object>> consumer) {}
 
     @Override
     public void trace(@Nullable String message) {}
 
     @Override
-    public void trace(@Nullable String message, @NotNull Function<FB, List<Field>> f) {}
+    public void trace(@Nullable String message, @NotNull Function<FB, Object> f) {}
 
     @Override
     public void trace(@Nullable String message, @NotNull Throwable e) {}
@@ -143,9 +143,7 @@ public class AsyncLogger<FB extends FieldBuilder> extends AbstractLoggerSupport<
 
     @Override
     public void trace(
-        @NotNull Condition condition,
-        @Nullable String message,
-        @NotNull Function<FB, List<Field>> f) {}
+        @NotNull Condition condition, @Nullable String message, @NotNull Function<FB, Object> f) {}
 
     @Override
     public void trace(
@@ -156,7 +154,7 @@ public class AsyncLogger<FB extends FieldBuilder> extends AbstractLoggerSupport<
      *
      * @param consumer the consumer of the logger handle.
      */
-    public void debug(@NotNull Consumer<LoggerHandle<FB>> consumer) {}
+    public void debug(@NotNull Consumer<LoggerHandle<FB, Object>> consumer) {}
 
     /**
      * Logs using a condition and a logger handle at DEBUG level.
@@ -164,13 +162,13 @@ public class AsyncLogger<FB extends FieldBuilder> extends AbstractLoggerSupport<
      * @param c the condition
      * @param consumer the consumer of the logger handle.
      */
-    public void debug(@NotNull Condition c, @NotNull Consumer<LoggerHandle<FB>> consumer) {}
+    public void debug(@NotNull Condition c, @NotNull Consumer<LoggerHandle<FB, Object>> consumer) {}
 
     @Override
     public void debug(@Nullable String message) {}
 
     @Override
-    public void debug(@Nullable String message, @NotNull Function<FB, List<Field>> f) {}
+    public void debug(@Nullable String message, @NotNull Function<FB, Object> f) {}
 
     @Override
     public void debug(@Nullable String message, @NotNull Throwable e) {}
@@ -180,9 +178,7 @@ public class AsyncLogger<FB extends FieldBuilder> extends AbstractLoggerSupport<
 
     @Override
     public void debug(
-        @NotNull Condition condition,
-        @Nullable String message,
-        @NotNull Function<FB, List<Field>> f) {}
+        @NotNull Condition condition, @Nullable String message, @NotNull Function<FB, Object> f) {}
 
     @Override
     public void debug(
@@ -193,7 +189,7 @@ public class AsyncLogger<FB extends FieldBuilder> extends AbstractLoggerSupport<
      *
      * @param consumer the consumer of the logger handle.
      */
-    public void info(@NotNull Consumer<LoggerHandle<FB>> consumer) {}
+    public void info(@NotNull Consumer<LoggerHandle<FB, Object>> consumer) {}
 
     /**
      * Logs using a condition and a logger handle at INFO level.
@@ -201,13 +197,13 @@ public class AsyncLogger<FB extends FieldBuilder> extends AbstractLoggerSupport<
      * @param c the condition
      * @param consumer the consumer of the logger handle.
      */
-    public void info(@NotNull Condition c, @NotNull Consumer<LoggerHandle<FB>> consumer) {}
+    public void info(@NotNull Condition c, @NotNull Consumer<LoggerHandle<FB, Object>> consumer) {}
 
     @Override
     public void info(@Nullable String message) {}
 
     @Override
-    public void info(@Nullable String message, @NotNull Function<FB, List<Field>> f) {}
+    public void info(@Nullable String message, @NotNull Function<FB, Object> f) {}
 
     @Override
     public void info(@Nullable String message, @NotNull Throwable e) {}
@@ -217,9 +213,7 @@ public class AsyncLogger<FB extends FieldBuilder> extends AbstractLoggerSupport<
 
     @Override
     public void info(
-        @NotNull Condition condition,
-        @Nullable String message,
-        @NotNull Function<FB, List<Field>> f) {}
+        @NotNull Condition condition, @Nullable String message, @NotNull Function<FB, Object> f) {}
 
     @Override
     public void info(
@@ -230,7 +224,7 @@ public class AsyncLogger<FB extends FieldBuilder> extends AbstractLoggerSupport<
      *
      * @param consumer the consumer of the logger handle.
      */
-    public void warn(@NotNull Consumer<LoggerHandle<FB>> consumer) {}
+    public void warn(@NotNull Consumer<LoggerHandle<FB, Object>> consumer) {}
 
     /**
      * Logs using a condition and a logger handle at WARN level.
@@ -238,10 +232,10 @@ public class AsyncLogger<FB extends FieldBuilder> extends AbstractLoggerSupport<
      * @param c the condition
      * @param consumer the consumer of the logger handle.
      */
-    public void warn(@NotNull Condition c, @NotNull Consumer<LoggerHandle<FB>> consumer) {}
+    public void warn(@NotNull Condition c, @NotNull Consumer<LoggerHandle<FB, Object>> consumer) {}
 
     @Override
-    public void warn(@Nullable String message, @NotNull Function<FB, List<Field>> f) {}
+    public void warn(@Nullable String message, @NotNull Function<FB, Object> f) {}
 
     @Override
     public void warn(@Nullable String message, @NotNull Throwable e) {}
@@ -251,9 +245,7 @@ public class AsyncLogger<FB extends FieldBuilder> extends AbstractLoggerSupport<
 
     @Override
     public void warn(
-        @NotNull Condition condition,
-        @Nullable String message,
-        @NotNull Function<FB, List<Field>> f) {}
+        @NotNull Condition condition, @Nullable String message, @NotNull Function<FB, Object> f) {}
 
     @Override
     public void warn(
@@ -265,7 +257,7 @@ public class AsyncLogger<FB extends FieldBuilder> extends AbstractLoggerSupport<
      * @param consumer the consumer of the logger handle.
      */
     @Override
-    public void error(@NotNull Consumer<LoggerHandle<FB>> consumer) {}
+    public void error(@NotNull Consumer<LoggerHandle<FB, Object>> consumer) {}
 
     /**
      * Logs using a condition and a logger handle at ERROR level.
@@ -274,13 +266,13 @@ public class AsyncLogger<FB extends FieldBuilder> extends AbstractLoggerSupport<
      * @param consumer the consumer of the logger handle.
      */
     @Override
-    public void error(@NotNull Condition c, @NotNull Consumer<LoggerHandle<FB>> consumer) {}
+    public void error(@NotNull Condition c, @NotNull Consumer<LoggerHandle<FB, Object>> consumer) {}
 
     @Override
     public void error(@Nullable String message) {}
 
     @Override
-    public void error(@Nullable String message, @NotNull Function<FB, List<Field>> f) {}
+    public void error(@Nullable String message, @NotNull Function<FB, Object> f) {}
 
     @Override
     public void error(@Nullable String message, @NotNull Throwable e) {}
@@ -290,9 +282,7 @@ public class AsyncLogger<FB extends FieldBuilder> extends AbstractLoggerSupport<
 
     @Override
     public void error(
-        @NotNull Condition condition,
-        @Nullable String message,
-        @NotNull Function<FB, List<Field>> f) {}
+        @NotNull Condition condition, @Nullable String message, @NotNull Function<FB, Object> f) {}
 
     @Override
     public void error(

--- a/async/src/main/java/com/tersesystems/echopraxia/async/AsyncLoggerMethods.java
+++ b/async/src/main/java/com/tersesystems/echopraxia/async/AsyncLoggerMethods.java
@@ -1,9 +1,7 @@
 package com.tersesystems.echopraxia.async;
 
 import com.tersesystems.echopraxia.api.Condition;
-import com.tersesystems.echopraxia.api.Field;
 import com.tersesystems.echopraxia.api.LoggerHandle;
-import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import org.jetbrains.annotations.NotNull;
@@ -14,9 +12,9 @@ import org.jetbrains.annotations.Nullable;
  *
  * @param <FB> the field builder type.
  */
-public interface AsyncLoggerMethods<FB> {
+public interface AsyncLoggerMethods<FB, RET> {
 
-  void trace(@NotNull Consumer<LoggerHandle<FB>> consumer);
+  void trace(@NotNull Consumer<LoggerHandle<FB, RET>> consumer);
 
   /**
    * Logs using a condition and a logger handle at TRACE level.
@@ -24,7 +22,7 @@ public interface AsyncLoggerMethods<FB> {
    * @param c the condition
    * @param consumer the consumer of the logger handle.
    */
-  void trace(@NotNull Condition c, @NotNull Consumer<LoggerHandle<FB>> consumer);
+  void trace(@NotNull Condition c, @NotNull Consumer<LoggerHandle<FB, RET>> consumer);
 
   /**
    * Logs statement at TRACE level.
@@ -39,7 +37,7 @@ public interface AsyncLoggerMethods<FB> {
    * @param message the message.
    * @param f the field builder function.
    */
-  void trace(@Nullable String message, @NotNull Function<FB, List<Field>> f);
+  void trace(@Nullable String message, @NotNull Function<FB, RET> f);
 
   /**
    * Logs statement at TRACE level with exception.
@@ -64,8 +62,7 @@ public interface AsyncLoggerMethods<FB> {
    * @param message the message.
    * @param f the field builder function.
    */
-  void trace(
-      @NotNull Condition condition, @Nullable String message, @NotNull Function<FB, List<Field>> f);
+  void trace(@NotNull Condition condition, @Nullable String message, @NotNull Function<FB, RET> f);
 
   /**
    * Conditionally logs statement at TRACE level with exception.
@@ -89,7 +86,7 @@ public interface AsyncLoggerMethods<FB> {
    * @param message the message.
    * @param f the field builder function.
    */
-  void debug(@Nullable String message, @NotNull Function<FB, List<Field>> f);
+  void debug(@Nullable String message, @NotNull Function<FB, RET> f);
 
   /**
    * Logs statement at DEBUG level with exception.
@@ -123,15 +120,14 @@ public interface AsyncLoggerMethods<FB> {
    * @param message the message.
    * @param f the field builder function.
    */
-  void debug(
-      @NotNull Condition condition, @Nullable String message, @NotNull Function<FB, List<Field>> f);
+  void debug(@NotNull Condition condition, @Nullable String message, @NotNull Function<FB, RET> f);
 
   /**
    * Logs using a logger handle at DEBUG level.
    *
    * @param consumer the consumer of the logger handle.
    */
-  void debug(@NotNull Consumer<LoggerHandle<FB>> consumer);
+  void debug(@NotNull Consumer<LoggerHandle<FB, RET>> consumer);
 
   /**
    * Logs using a condition and a logger handle at DEBUG level.
@@ -139,7 +135,7 @@ public interface AsyncLoggerMethods<FB> {
    * @param c the condition
    * @param consumer the consumer of the logger handle.
    */
-  void debug(@NotNull Condition c, @NotNull Consumer<LoggerHandle<FB>> consumer);
+  void debug(@NotNull Condition c, @NotNull Consumer<LoggerHandle<FB, RET>> consumer);
 
   /**
    * Logs statement at INFO level.
@@ -154,7 +150,7 @@ public interface AsyncLoggerMethods<FB> {
    * @param message the message.
    * @param f the field builder function.
    */
-  void info(@Nullable String message, @NotNull Function<FB, List<Field>> f);
+  void info(@Nullable String message, @NotNull Function<FB, RET> f);
 
   /**
    * Logs statement at INFO level with exception.
@@ -179,8 +175,7 @@ public interface AsyncLoggerMethods<FB> {
    * @param message the message.
    * @param f the field builder function.
    */
-  void info(
-      @NotNull Condition condition, @Nullable String message, @NotNull Function<FB, List<Field>> f);
+  void info(@NotNull Condition condition, @Nullable String message, @NotNull Function<FB, RET> f);
 
   /**
    * Conditionally logs statement at INFO level with exception.
@@ -197,7 +192,7 @@ public interface AsyncLoggerMethods<FB> {
    * @param c the condition
    * @param consumer the consumer of the logger handle.
    */
-  void info(@NotNull Condition c, @NotNull Consumer<LoggerHandle<FB>> consumer);
+  void info(@NotNull Condition c, @NotNull Consumer<LoggerHandle<FB, RET>> consumer);
 
   /**
    * Logs statement at WARN level.
@@ -212,7 +207,7 @@ public interface AsyncLoggerMethods<FB> {
    * @param message the message.
    * @param f the field builder function.
    */
-  void warn(@Nullable String message, @NotNull Function<FB, List<Field>> f);
+  void warn(@Nullable String message, @NotNull Function<FB, RET> f);
 
   /**
    * Logs statement at WARN level with exception.
@@ -246,14 +241,13 @@ public interface AsyncLoggerMethods<FB> {
    * @param message the message.
    * @param f the field builder function.
    */
-  void warn(
-      @NotNull Condition condition, @Nullable String message, @NotNull Function<FB, List<Field>> f);
+  void warn(@NotNull Condition condition, @Nullable String message, @NotNull Function<FB, RET> f);
   /**
    * Logs using a logger handle at WARN level.
    *
    * @param consumer the consumer of the logger handle.
    */
-  void warn(@NotNull Consumer<LoggerHandle<FB>> consumer);
+  void warn(@NotNull Consumer<LoggerHandle<FB, RET>> consumer);
 
   /**
    * Logs using a condition and a logger handle at WARN level.
@@ -261,7 +255,7 @@ public interface AsyncLoggerMethods<FB> {
    * @param c the condition
    * @param consumer the consumer of the logger handle.
    */
-  void warn(@NotNull Condition c, @NotNull Consumer<LoggerHandle<FB>> consumer);
+  void warn(@NotNull Condition c, @NotNull Consumer<LoggerHandle<FB, RET>> consumer);
 
   /**
    * Logs statement at INFO level.
@@ -276,7 +270,7 @@ public interface AsyncLoggerMethods<FB> {
    * @param message the message.
    * @param f the field builder function.
    */
-  void error(@Nullable String message, @NotNull Function<FB, List<Field>> f);
+  void error(@Nullable String message, @NotNull Function<FB, RET> f);
 
   /**
    * Logs statement at INFO level with exception.
@@ -301,8 +295,7 @@ public interface AsyncLoggerMethods<FB> {
    * @param message the message.
    * @param f the field builder function.
    */
-  void error(
-      @NotNull Condition condition, @Nullable String message, @NotNull Function<FB, List<Field>> f);
+  void error(@NotNull Condition condition, @Nullable String message, @NotNull Function<FB, RET> f);
 
   /**
    * Conditionally logs statement at INFO level with exception.
@@ -318,7 +311,7 @@ public interface AsyncLoggerMethods<FB> {
    *
    * @param consumer the consumer of the logger handle.
    */
-  void error(@NotNull Consumer<LoggerHandle<FB>> consumer);
+  void error(@NotNull Consumer<LoggerHandle<FB, RET>> consumer);
 
   /**
    * Logs using a condition and a logger handle at ERROR level.
@@ -326,5 +319,5 @@ public interface AsyncLoggerMethods<FB> {
    * @param c the condition
    * @param consumer the consumer of the logger handle.
    */
-  void error(@NotNull Condition c, @NotNull Consumer<LoggerHandle<FB>> consumer);
+  void error(@NotNull Condition c, @NotNull Consumer<LoggerHandle<FB, RET>> consumer);
 }

--- a/async/src/main/java/com/tersesystems/echopraxia/async/DefaultAsyncLoggerMethods.java
+++ b/async/src/main/java/com/tersesystems/echopraxia/async/DefaultAsyncLoggerMethods.java
@@ -9,7 +9,6 @@ import com.tersesystems.echopraxia.api.Condition;
 import com.tersesystems.echopraxia.api.DefaultMethodsSupport;
 import com.tersesystems.echopraxia.api.Field;
 import com.tersesystems.echopraxia.api.LoggerHandle;
-import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import org.jetbrains.annotations.NotNull;
@@ -20,8 +19,8 @@ import org.jetbrains.annotations.Nullable;
  *
  * @param <FB> the field builder.
  */
-public interface DefaultAsyncLoggerMethods<FB>
-    extends AsyncLoggerMethods<FB>, DefaultMethodsSupport<FB> {
+public interface DefaultAsyncLoggerMethods<FB, RET>
+    extends AsyncLoggerMethods<FB, RET>, DefaultMethodsSupport<FB> {
 
   // ------------------------------------------------------------------------
   // TRACE
@@ -31,7 +30,7 @@ public interface DefaultAsyncLoggerMethods<FB>
    *
    * @param consumer the consumer of the logger handle.
    */
-  default void trace(@NotNull Consumer<LoggerHandle<FB>> consumer) {
+  default void trace(@NotNull Consumer<LoggerHandle<FB, RET>> consumer) {
     core().asyncLog(TRACE, consumer, fieldBuilder());
   }
 
@@ -41,7 +40,7 @@ public interface DefaultAsyncLoggerMethods<FB>
    * @param c the condition
    * @param consumer the consumer of the logger handle.
    */
-  default void trace(@NotNull Condition c, @NotNull Consumer<LoggerHandle<FB>> consumer) {
+  default void trace(@NotNull Condition c, @NotNull Consumer<LoggerHandle<FB, RET>> consumer) {
     core().asyncLog(TRACE, c, consumer, fieldBuilder());
   }
 
@@ -60,8 +59,8 @@ public interface DefaultAsyncLoggerMethods<FB>
    * @param message the message.
    * @param f the field builder function.
    */
-  default void trace(@Nullable String message, @NotNull Function<FB, List<Field>> f) {
-    core().asyncLog(TRACE, h -> h.log(message, f), fieldBuilder());
+  default void trace(@Nullable String message, @NotNull Function<FB, RET> f) {
+    core().asyncLog(TRACE, (LoggerHandle<FB, RET> h) -> h.log(message, f), fieldBuilder());
   }
 
   /**
@@ -96,10 +95,9 @@ public interface DefaultAsyncLoggerMethods<FB>
    * @param f the field builder function.
    */
   default void trace(
-      @NotNull Condition condition,
-      @Nullable String message,
-      @NotNull Function<FB, List<Field>> f) {
-    core().asyncLog(TRACE, condition, h -> h.log(message, f), fieldBuilder());
+      @NotNull Condition condition, @Nullable String message, @NotNull Function<FB, RET> f) {
+    core()
+        .asyncLog(TRACE, condition, (LoggerHandle<FB, RET> h) -> h.log(message, f), fieldBuilder());
   }
 
   /**
@@ -126,7 +124,7 @@ public interface DefaultAsyncLoggerMethods<FB>
    *
    * @param consumer the consumer of the logger handle.
    */
-  default void debug(@NotNull Consumer<LoggerHandle<FB>> consumer) {
+  default void debug(@NotNull Consumer<LoggerHandle<FB, RET>> consumer) {
     core().asyncLog(DEBUG, consumer, fieldBuilder());
   }
 
@@ -136,7 +134,7 @@ public interface DefaultAsyncLoggerMethods<FB>
    * @param c the condition
    * @param consumer the consumer of the logger handle.
    */
-  default void debug(@NotNull Condition c, @NotNull Consumer<LoggerHandle<FB>> consumer) {
+  default void debug(@NotNull Condition c, @NotNull Consumer<LoggerHandle<FB, RET>> consumer) {
     core().asyncLog(DEBUG, c, consumer, fieldBuilder());
   }
 
@@ -155,8 +153,8 @@ public interface DefaultAsyncLoggerMethods<FB>
    * @param message the message.
    * @param f the field builder function.
    */
-  default void debug(@Nullable String message, @NotNull Function<FB, List<Field>> f) {
-    core().asyncLog(DEBUG, h -> h.log(message, f), fieldBuilder());
+  default void debug(@Nullable String message, @NotNull Function<FB, RET> f) {
+    core().asyncLog(DEBUG, (LoggerHandle<FB, RET> h) -> h.log(message, f), fieldBuilder());
   }
 
   /**
@@ -191,10 +189,9 @@ public interface DefaultAsyncLoggerMethods<FB>
    * @param f the field builder function.
    */
   default void debug(
-      @NotNull Condition condition,
-      @Nullable String message,
-      @NotNull Function<FB, List<Field>> f) {
-    core().asyncLog(DEBUG, condition, h -> h.log(message, f), fieldBuilder());
+      @NotNull Condition condition, @Nullable String message, @NotNull Function<FB, RET> f) {
+    core()
+        .asyncLog(DEBUG, condition, (LoggerHandle<FB, RET> h) -> h.log(message, f), fieldBuilder());
   }
 
   /**
@@ -221,7 +218,7 @@ public interface DefaultAsyncLoggerMethods<FB>
    *
    * @param consumer the consumer of the logger handle.
    */
-  default void info(@NotNull Consumer<LoggerHandle<FB>> consumer) {
+  default void info(@NotNull Consumer<LoggerHandle<FB, RET>> consumer) {
     core().asyncLog(INFO, consumer, fieldBuilder());
   }
 
@@ -231,7 +228,7 @@ public interface DefaultAsyncLoggerMethods<FB>
    * @param c the condition
    * @param consumer the consumer of the logger handle.
    */
-  default void info(@NotNull Condition c, @NotNull Consumer<LoggerHandle<FB>> consumer) {
+  default void info(@NotNull Condition c, @NotNull Consumer<LoggerHandle<FB, RET>> consumer) {
     core().asyncLog(INFO, c, consumer, fieldBuilder());
   }
 
@@ -250,8 +247,8 @@ public interface DefaultAsyncLoggerMethods<FB>
    * @param message the message.
    * @param f the field builder function.
    */
-  default void info(@Nullable String message, @NotNull Function<FB, List<Field>> f) {
-    core().asyncLog(INFO, h -> h.log(message, f), fieldBuilder());
+  default void info(@Nullable String message, @NotNull Function<FB, RET> f) {
+    core().asyncLog(INFO, (LoggerHandle<FB, RET> h) -> h.log(message, f), fieldBuilder());
   }
 
   /**
@@ -286,10 +283,9 @@ public interface DefaultAsyncLoggerMethods<FB>
    * @param f the field builder function.
    */
   default void info(
-      @NotNull Condition condition,
-      @Nullable String message,
-      @NotNull Function<FB, List<Field>> f) {
-    core().asyncLog(INFO, condition, h -> h.log(message, f), fieldBuilder());
+      @NotNull Condition condition, @Nullable String message, @NotNull Function<FB, RET> f) {
+    core()
+        .asyncLog(INFO, condition, (LoggerHandle<FB, RET> h) -> h.log(message, f), fieldBuilder());
   }
 
   /**
@@ -316,7 +312,7 @@ public interface DefaultAsyncLoggerMethods<FB>
    *
    * @param consumer the consumer of the logger handle.
    */
-  default void warn(@NotNull Consumer<LoggerHandle<FB>> consumer) {
+  default void warn(@NotNull Consumer<LoggerHandle<FB, RET>> consumer) {
     core().asyncLog(WARN, consumer, fieldBuilder());
   }
 
@@ -326,7 +322,7 @@ public interface DefaultAsyncLoggerMethods<FB>
    * @param c the condition
    * @param consumer the consumer of the logger handle.
    */
-  default void warn(@NotNull Condition c, @NotNull Consumer<LoggerHandle<FB>> consumer) {
+  default void warn(@NotNull Condition c, @NotNull Consumer<LoggerHandle<FB, RET>> consumer) {
     core().asyncLog(WARN, c, consumer, fieldBuilder());
   }
 
@@ -345,8 +341,8 @@ public interface DefaultAsyncLoggerMethods<FB>
    * @param message the message.
    * @param f the field builder function.
    */
-  default void warn(@Nullable String message, @NotNull Function<FB, List<Field>> f) {
-    core().asyncLog(WARN, h -> h.log(message, f), fieldBuilder());
+  default void warn(@Nullable String message, @NotNull Function<FB, RET> f) {
+    core().asyncLog(WARN, (LoggerHandle<FB, RET> h) -> h.log(message, f), fieldBuilder());
   }
 
   /**
@@ -381,10 +377,9 @@ public interface DefaultAsyncLoggerMethods<FB>
    * @param f the field builder function.
    */
   default void warn(
-      @NotNull Condition condition,
-      @Nullable String message,
-      @NotNull Function<FB, List<Field>> f) {
-    core().asyncLog(WARN, condition, h -> h.log(message, f), fieldBuilder());
+      @NotNull Condition condition, @Nullable String message, @NotNull Function<FB, RET> f) {
+    core()
+        .asyncLog(WARN, condition, (LoggerHandle<FB, RET> h) -> h.log(message, f), fieldBuilder());
   }
 
   /**
@@ -411,7 +406,7 @@ public interface DefaultAsyncLoggerMethods<FB>
    *
    * @param consumer the consumer of the logger handle.
    */
-  default void error(@NotNull Consumer<LoggerHandle<FB>> consumer) {
+  default void error(@NotNull Consumer<LoggerHandle<FB, RET>> consumer) {
     core().asyncLog(ERROR, consumer, fieldBuilder());
   }
 
@@ -421,7 +416,7 @@ public interface DefaultAsyncLoggerMethods<FB>
    * @param c the condition
    * @param consumer the consumer of the logger handle.
    */
-  default void error(@NotNull Condition c, @NotNull Consumer<LoggerHandle<FB>> consumer) {
+  default void error(@NotNull Condition c, @NotNull Consumer<LoggerHandle<FB, RET>> consumer) {
     core().asyncLog(ERROR, c, consumer, fieldBuilder());
   }
 
@@ -440,8 +435,8 @@ public interface DefaultAsyncLoggerMethods<FB>
    * @param message the message.
    * @param f the field builder function.
    */
-  default void error(@Nullable String message, @NotNull Function<FB, List<Field>> f) {
-    core().asyncLog(ERROR, h -> h.log(message, f), fieldBuilder());
+  default void error(@Nullable String message, @NotNull Function<FB, RET> f) {
+    core().asyncLog(ERROR, (LoggerHandle<FB, RET> h) -> h.log(message, f), fieldBuilder());
   }
 
   /**
@@ -476,10 +471,9 @@ public interface DefaultAsyncLoggerMethods<FB>
    * @param f the field builder function.
    */
   default void error(
-      @NotNull Condition condition,
-      @Nullable String message,
-      @NotNull Function<FB, List<Field>> f) {
-    core().asyncLog(ERROR, condition, h -> h.log(message, f), fieldBuilder());
+      @NotNull Condition condition, @Nullable String message, @NotNull Function<FB, RET> f) {
+    core()
+        .asyncLog(ERROR, condition, (LoggerHandle<FB, RET> h) -> h.log(message, f), fieldBuilder());
   }
 
   /**

--- a/log4j/src/main/java/com/tersesystems/echopraxia/log4j/Log4JCoreLogger.java
+++ b/log4j/src/main/java/com/tersesystems/echopraxia/log4j/Log4JCoreLogger.java
@@ -175,16 +175,16 @@ public class Log4JCoreLogger implements CoreLogger {
   }
 
   @Override
-  public <FB> void log(
+  public <FB, RET> void log(
       @NotNull Level level,
       @Nullable String messageTemplate,
-      @NotNull Function<FB, List<Field>> f,
+      @NotNull Function<FB, RET> f,
       @NotNull FB builder) {
     // because the isEnabled check looks for message and throwable, we have to
     // calculate them right up front.
     final Marker marker = context.getMarker();
     final org.apache.logging.log4j.Level log4jLevel = convertLevel(level);
-    final List<Field> argumentFields = f.apply(builder);
+    final List<Field> argumentFields = (List<Field>) f.apply(builder);
     final Throwable e = findThrowable(argumentFields);
     // When passing a condition through with explicit arguments, we pull the args and make
     // them available through context.
@@ -208,15 +208,15 @@ public class Log4JCoreLogger implements CoreLogger {
   }
 
   @Override
-  public <FB> void log(
+  public <FB, RET> void log(
       @NotNull Level level,
       @NotNull Condition condition,
       @Nullable String messageTemplate,
-      @NotNull Function<FB, List<Field>> f,
+      @NotNull Function<FB, RET> f,
       @NotNull FB builder) {
     final Marker marker = context.getMarker();
     final org.apache.logging.log4j.Level log4jLevel = convertLevel(level);
-    final List<Field> argumentFields = f.apply(builder);
+    final List<Field> argumentFields = (List<Field>) f.apply(builder);
     final Throwable e = findThrowable(argumentFields);
     // When passing a condition through with explicit arguments, we pull the args and make
     // them available through context.

--- a/logger/src/main/java/com/tersesystems/echopraxia/DefaultLoggerMethods.java
+++ b/logger/src/main/java/com/tersesystems/echopraxia/DefaultLoggerMethods.java
@@ -9,7 +9,6 @@ import static java.util.Collections.singletonList;
 import com.tersesystems.echopraxia.api.Condition;
 import com.tersesystems.echopraxia.api.DefaultMethodsSupport;
 import com.tersesystems.echopraxia.api.Field;
-import java.util.List;
 import java.util.function.Function;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -19,7 +18,8 @@ import org.jetbrains.annotations.Nullable;
  *
  * @param <FB> the field builder type
  */
-public interface DefaultLoggerMethods<FB, RET> extends LoggerMethods<FB, RET>, DefaultMethodsSupport<FB> {
+public interface DefaultLoggerMethods<FB, RET>
+    extends LoggerMethods<FB, RET>, DefaultMethodsSupport<FB> {
 
   // ------------------------------------------------------------------------
   // TRACE
@@ -89,9 +89,7 @@ public interface DefaultLoggerMethods<FB, RET> extends LoggerMethods<FB, RET>, D
    * @param f the field builder function.
    */
   default void trace(
-      @NotNull Condition condition,
-      @Nullable String message,
-      @NotNull Function<FB, RET> f) {
+      @NotNull Condition condition, @Nullable String message, @NotNull Function<FB, RET> f) {
     core().log(TRACE, condition, message, f, fieldBuilder());
   }
 
@@ -197,9 +195,7 @@ public interface DefaultLoggerMethods<FB, RET> extends LoggerMethods<FB, RET>, D
    * @param f the field builder function.
    */
   default void debug(
-      @NotNull Condition condition,
-      @Nullable String message,
-      @NotNull Function<FB, RET> f) {
+      @NotNull Condition condition, @Nullable String message, @NotNull Function<FB, RET> f) {
     core().log(DEBUG, condition, message, f, fieldBuilder());
   }
 
@@ -271,9 +267,7 @@ public interface DefaultLoggerMethods<FB, RET> extends LoggerMethods<FB, RET>, D
    * @param f the field builder function.
    */
   default void info(
-      @NotNull Condition condition,
-      @Nullable String message,
-      @NotNull Function<FB, RET> f) {
+      @NotNull Condition condition, @Nullable String message, @NotNull Function<FB, RET> f) {
     core().log(INFO, condition, message, f, fieldBuilder());
   }
 
@@ -379,9 +373,7 @@ public interface DefaultLoggerMethods<FB, RET> extends LoggerMethods<FB, RET>, D
    * @param f the field builder function.
    */
   default void warn(
-      @NotNull Condition condition,
-      @Nullable String message,
-      @NotNull Function<FB, RET> f) {
+      @NotNull Condition condition, @Nullable String message, @NotNull Function<FB, RET> f) {
     core().log(WARN, condition, message, f, fieldBuilder());
   }
 
@@ -453,9 +445,7 @@ public interface DefaultLoggerMethods<FB, RET> extends LoggerMethods<FB, RET>, D
    * @param f the field builder function.
    */
   default void error(
-      @NotNull Condition condition,
-      @Nullable String message,
-      @NotNull Function<FB, RET> f) {
+      @NotNull Condition condition, @Nullable String message, @NotNull Function<FB, RET> f) {
     core().log(ERROR, condition, message, f, fieldBuilder());
   }
 

--- a/logger/src/main/java/com/tersesystems/echopraxia/DefaultLoggerMethods.java
+++ b/logger/src/main/java/com/tersesystems/echopraxia/DefaultLoggerMethods.java
@@ -19,7 +19,7 @@ import org.jetbrains.annotations.Nullable;
  *
  * @param <FB> the field builder type
  */
-public interface DefaultLoggerMethods<FB> extends LoggerMethods<FB>, DefaultMethodsSupport<FB> {
+public interface DefaultLoggerMethods<FB, RET> extends LoggerMethods<FB, RET>, DefaultMethodsSupport<FB> {
 
   // ------------------------------------------------------------------------
   // TRACE
@@ -52,7 +52,7 @@ public interface DefaultLoggerMethods<FB> extends LoggerMethods<FB>, DefaultMeth
    * @param message the message.
    * @param f the field builder function.
    */
-  default void trace(@Nullable String message, Function<FB, List<Field>> f) {
+  default void trace(@Nullable String message, @NotNull Function<FB, RET> f) {
     core().log(TRACE, message, f, fieldBuilder());
   }
 
@@ -91,7 +91,7 @@ public interface DefaultLoggerMethods<FB> extends LoggerMethods<FB>, DefaultMeth
   default void trace(
       @NotNull Condition condition,
       @Nullable String message,
-      @NotNull Function<FB, List<Field>> f) {
+      @NotNull Function<FB, RET> f) {
     core().log(TRACE, condition, message, f, fieldBuilder());
   }
 
@@ -143,7 +143,7 @@ public interface DefaultLoggerMethods<FB> extends LoggerMethods<FB>, DefaultMeth
    * @param message the message.
    * @param f the field builder function.
    */
-  default void debug(@Nullable String message, @NotNull Function<FB, List<Field>> f) {
+  default void debug(@Nullable String message, @NotNull Function<FB, RET> f) {
     core().log(DEBUG, message, f, fieldBuilder());
   }
 
@@ -199,7 +199,7 @@ public interface DefaultLoggerMethods<FB> extends LoggerMethods<FB>, DefaultMeth
   default void debug(
       @NotNull Condition condition,
       @Nullable String message,
-      @NotNull Function<FB, List<Field>> f) {
+      @NotNull Function<FB, RET> f) {
     core().log(DEBUG, condition, message, f, fieldBuilder());
   }
 
@@ -234,7 +234,7 @@ public interface DefaultLoggerMethods<FB> extends LoggerMethods<FB>, DefaultMeth
    * @param message the message.
    * @param f the field builder function.
    */
-  default void info(@Nullable String message, @NotNull Function<FB, List<Field>> f) {
+  default void info(@Nullable String message, @NotNull Function<FB, RET> f) {
     core().log(INFO, message, f, fieldBuilder());
   }
 
@@ -273,7 +273,7 @@ public interface DefaultLoggerMethods<FB> extends LoggerMethods<FB>, DefaultMeth
   default void info(
       @NotNull Condition condition,
       @Nullable String message,
-      @NotNull Function<FB, List<Field>> f) {
+      @NotNull Function<FB, RET> f) {
     core().log(INFO, condition, message, f, fieldBuilder());
   }
 
@@ -325,7 +325,7 @@ public interface DefaultLoggerMethods<FB> extends LoggerMethods<FB>, DefaultMeth
    * @param message the message.
    * @param f the field builder function.
    */
-  default void warn(@Nullable String message, @NotNull Function<FB, List<Field>> f) {
+  default void warn(@Nullable String message, @NotNull Function<FB, RET> f) {
     core().log(WARN, message, f, fieldBuilder());
   }
 
@@ -381,7 +381,7 @@ public interface DefaultLoggerMethods<FB> extends LoggerMethods<FB>, DefaultMeth
   default void warn(
       @NotNull Condition condition,
       @Nullable String message,
-      @NotNull Function<FB, List<Field>> f) {
+      @NotNull Function<FB, RET> f) {
     core().log(WARN, condition, message, f, fieldBuilder());
   }
 
@@ -416,7 +416,7 @@ public interface DefaultLoggerMethods<FB> extends LoggerMethods<FB>, DefaultMeth
    * @param message the message.
    * @param f the field builder function.
    */
-  default void error(@Nullable String message, @NotNull Function<FB, List<Field>> f) {
+  default void error(@Nullable String message, @NotNull Function<FB, RET> f) {
     core().log(ERROR, message, f, fieldBuilder());
   }
 
@@ -455,7 +455,7 @@ public interface DefaultLoggerMethods<FB> extends LoggerMethods<FB>, DefaultMeth
   default void error(
       @NotNull Condition condition,
       @Nullable String message,
-      @NotNull Function<FB, List<Field>> f) {
+      @NotNull Function<FB, RET> f) {
     core().log(ERROR, condition, message, f, fieldBuilder());
   }
 

--- a/logger/src/main/java/com/tersesystems/echopraxia/Logger.java
+++ b/logger/src/main/java/com/tersesystems/echopraxia/Logger.java
@@ -12,7 +12,7 @@ import org.jetbrains.annotations.Nullable;
  * @param <FB> the field builder type.
  */
 public class Logger<FB extends FieldBuilder> extends AbstractLoggerSupport<Logger<FB>, FB>
-    implements DefaultLoggerMethods<FB> {
+    implements DefaultLoggerMethods<FB, List<Field>> {
 
   // This is where the logging methods are called, so the stacktrace element shows
   // DefaultLoggerMethods as the caller.
@@ -107,7 +107,7 @@ public class Logger<FB extends FieldBuilder> extends AbstractLoggerSupport<Logge
     }
 
     @Override
-    public void trace(@Nullable String message, Function<FB, List<Field>> f) {
+    public void trace(@Nullable String message, @NotNull Function<FB, List<Field>> f) {
       // do nothing
     }
 

--- a/logger/src/main/java/com/tersesystems/echopraxia/Logger.java
+++ b/logger/src/main/java/com/tersesystems/echopraxia/Logger.java
@@ -1,7 +1,6 @@
 package com.tersesystems.echopraxia;
 
 import com.tersesystems.echopraxia.api.*;
-import java.util.List;
 import java.util.function.Function;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -11,8 +10,8 @@ import org.jetbrains.annotations.Nullable;
  *
  * @param <FB> the field builder type.
  */
-public class Logger<FB extends FieldBuilder> extends AbstractLoggerSupport<Logger<FB>, FB>
-    implements DefaultLoggerMethods<FB, List<Field>> {
+public class Logger<FB extends FieldBuilder> extends AbstractLoggerSupport<Logger<FB>, FB, Object>
+    implements DefaultLoggerMethods<FB, Object> {
 
   // This is where the logging methods are called, so the stacktrace element shows
   // DefaultLoggerMethods as the caller.
@@ -79,7 +78,7 @@ public class Logger<FB extends FieldBuilder> extends AbstractLoggerSupport<Logge
     }
 
     @Override
-    public @NotNull Logger<FB> withFields(@NotNull Function<FB, List<Field>> f) {
+    public @NotNull Logger<FB> withFields(@NotNull Function<FB, Object> f) {
       return this;
     }
 
@@ -107,7 +106,7 @@ public class Logger<FB extends FieldBuilder> extends AbstractLoggerSupport<Logge
     }
 
     @Override
-    public void trace(@Nullable String message, @NotNull Function<FB, List<Field>> f) {
+    public void trace(@Nullable String message, @NotNull Function<FB, Object> f) {
       // do nothing
     }
 
@@ -123,9 +122,7 @@ public class Logger<FB extends FieldBuilder> extends AbstractLoggerSupport<Logge
 
     @Override
     public void trace(
-        @NotNull Condition condition,
-        @Nullable String message,
-        @NotNull Function<FB, List<Field>> f) {
+        @NotNull Condition condition, @Nullable String message, @NotNull Function<FB, Object> f) {
       // do nothing
     }
 
@@ -154,7 +151,7 @@ public class Logger<FB extends FieldBuilder> extends AbstractLoggerSupport<Logge
     }
 
     @Override
-    public void debug(@Nullable String message, @NotNull Function<FB, List<Field>> f) {
+    public void debug(@Nullable String message, @NotNull Function<FB, Object> f) {
       // do nothing
     }
 
@@ -170,9 +167,7 @@ public class Logger<FB extends FieldBuilder> extends AbstractLoggerSupport<Logge
 
     @Override
     public void debug(
-        @NotNull Condition condition,
-        @Nullable String message,
-        @NotNull Function<FB, List<Field>> f) {
+        @NotNull Condition condition, @Nullable String message, @NotNull Function<FB, Object> f) {
       // do nothing
     }
 
@@ -201,7 +196,7 @@ public class Logger<FB extends FieldBuilder> extends AbstractLoggerSupport<Logge
     }
 
     @Override
-    public void info(@Nullable String message, @NotNull Function<FB, List<Field>> f) {
+    public void info(@Nullable String message, @NotNull Function<FB, Object> f) {
       // do nothing
     }
 
@@ -217,9 +212,7 @@ public class Logger<FB extends FieldBuilder> extends AbstractLoggerSupport<Logge
 
     @Override
     public void info(
-        @NotNull Condition condition,
-        @Nullable String message,
-        @NotNull Function<FB, List<Field>> f) {
+        @NotNull Condition condition, @Nullable String message, @NotNull Function<FB, Object> f) {
       // do nothing
     }
 
@@ -242,7 +235,7 @@ public class Logger<FB extends FieldBuilder> extends AbstractLoggerSupport<Logge
     }
 
     @Override
-    public void warn(@Nullable String message, @NotNull Function<FB, List<Field>> f) {
+    public void warn(@Nullable String message, @NotNull Function<FB, Object> f) {
       // do nothing
     }
 
@@ -258,9 +251,7 @@ public class Logger<FB extends FieldBuilder> extends AbstractLoggerSupport<Logge
 
     @Override
     public void warn(
-        @NotNull Condition condition,
-        @Nullable String message,
-        @NotNull Function<FB, List<Field>> f) {
+        @NotNull Condition condition, @Nullable String message, @NotNull Function<FB, Object> f) {
       // do nothing
     }
 
@@ -288,7 +279,7 @@ public class Logger<FB extends FieldBuilder> extends AbstractLoggerSupport<Logge
     }
 
     @Override
-    public void error(@Nullable String message, @NotNull Function<FB, List<Field>> f) {
+    public void error(@Nullable String message, @NotNull Function<FB, Object> f) {
       // do nothing
     }
 
@@ -304,9 +295,7 @@ public class Logger<FB extends FieldBuilder> extends AbstractLoggerSupport<Logge
 
     @Override
     public void error(
-        @NotNull Condition condition,
-        @Nullable String message,
-        @NotNull Function<FB, List<Field>> f) {
+        @NotNull Condition condition, @Nullable String message, @NotNull Function<FB, Object> f) {
       // do nothing
     }
 

--- a/logger/src/main/java/com/tersesystems/echopraxia/LoggerMethods.java
+++ b/logger/src/main/java/com/tersesystems/echopraxia/LoggerMethods.java
@@ -12,7 +12,7 @@ import org.jetbrains.annotations.Nullable;
  *
  * @param <FB> the field builder type.
  */
-public interface LoggerMethods<FB> {
+public interface LoggerMethods<FB, RET> {
 
   /** @return true if the logger level is TRACE or higher. */
   boolean isTraceEnabled();
@@ -72,7 +72,7 @@ public interface LoggerMethods<FB> {
    * @param message the message.
    * @param f the field builder function.
    */
-  void trace(@Nullable String message, @NotNull Function<FB, List<Field>> f);
+  void trace(@Nullable String message, @NotNull Function<FB, RET> f);
 
   /**
    * Logs statement at TRACE level with exception.
@@ -98,7 +98,7 @@ public interface LoggerMethods<FB> {
    * @param f the field builder function.
    */
   void trace(
-      @NotNull Condition condition, @Nullable String message, @NotNull Function<FB, List<Field>> f);
+      @NotNull Condition condition, @Nullable String message, @NotNull Function<FB, RET> f);
 
   /**
    * Conditionally logs statement at TRACE level with exception.
@@ -122,7 +122,7 @@ public interface LoggerMethods<FB> {
    * @param message the message.
    * @param f the field builder function.
    */
-  void debug(@Nullable String message, @NotNull Function<FB, List<Field>> f);
+  void debug(@Nullable String message, @NotNull Function<FB, RET> f);
 
   /**
    * Logs statement at DEBUG level with exception.
@@ -157,7 +157,7 @@ public interface LoggerMethods<FB> {
    * @param f the field builder function.
    */
   void debug(
-      @NotNull Condition condition, @Nullable String message, @NotNull Function<FB, List<Field>> f);
+      @NotNull Condition condition, @Nullable String message, @NotNull Function<FB, RET> f);
 
   /**
    * Logs statement at INFO level.
@@ -172,7 +172,7 @@ public interface LoggerMethods<FB> {
    * @param message the message.
    * @param f the field builder function.
    */
-  void info(@Nullable String message, @NotNull Function<FB, List<Field>> f);
+  void info(@Nullable String message, @NotNull Function<FB, RET> f);
 
   /**
    * Logs statement at INFO level with exception.
@@ -198,7 +198,7 @@ public interface LoggerMethods<FB> {
    * @param f the field builder function.
    */
   void info(
-      @NotNull Condition condition, @Nullable String message, @NotNull Function<FB, List<Field>> f);
+      @NotNull Condition condition, @Nullable String message, @NotNull Function<FB, RET> f);
 
   /**
    * Conditionally logs statement at INFO level with exception.
@@ -222,7 +222,7 @@ public interface LoggerMethods<FB> {
    * @param message the message.
    * @param f the field builder function.
    */
-  void warn(@Nullable String message, @NotNull Function<FB, List<Field>> f);
+  void warn(@Nullable String message, @NotNull Function<FB, RET> f);
 
   /**
    * Logs statement at WARN level with exception.
@@ -257,7 +257,7 @@ public interface LoggerMethods<FB> {
    * @param f the field builder function.
    */
   void warn(
-      @NotNull Condition condition, @Nullable String message, @NotNull Function<FB, List<Field>> f);
+      @NotNull Condition condition, @Nullable String message, @NotNull Function<FB, RET> f);
 
   /**
    * Logs statement at INFO level.
@@ -272,7 +272,7 @@ public interface LoggerMethods<FB> {
    * @param message the message.
    * @param f the field builder function.
    */
-  void error(@Nullable String message, @NotNull Function<FB, List<Field>> f);
+  void error(@Nullable String message, @NotNull Function<FB, RET> f);
 
   /**
    * Logs statement at INFO level with exception.
@@ -298,7 +298,7 @@ public interface LoggerMethods<FB> {
    * @param f the field builder function.
    */
   void error(
-      @NotNull Condition condition, @Nullable String message, @NotNull Function<FB, List<Field>> f);
+      @NotNull Condition condition, @Nullable String message, @NotNull Function<FB, RET> f);
 
   /**
    * Conditionally logs statement at INFO level with exception.

--- a/logger/src/main/java/com/tersesystems/echopraxia/LoggerMethods.java
+++ b/logger/src/main/java/com/tersesystems/echopraxia/LoggerMethods.java
@@ -1,8 +1,6 @@
 package com.tersesystems.echopraxia;
 
 import com.tersesystems.echopraxia.api.Condition;
-import com.tersesystems.echopraxia.api.Field;
-import java.util.List;
 import java.util.function.Function;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -97,8 +95,7 @@ public interface LoggerMethods<FB, RET> {
    * @param message the message.
    * @param f the field builder function.
    */
-  void trace(
-      @NotNull Condition condition, @Nullable String message, @NotNull Function<FB, RET> f);
+  void trace(@NotNull Condition condition, @Nullable String message, @NotNull Function<FB, RET> f);
 
   /**
    * Conditionally logs statement at TRACE level with exception.
@@ -156,8 +153,7 @@ public interface LoggerMethods<FB, RET> {
    * @param message the message.
    * @param f the field builder function.
    */
-  void debug(
-      @NotNull Condition condition, @Nullable String message, @NotNull Function<FB, RET> f);
+  void debug(@NotNull Condition condition, @Nullable String message, @NotNull Function<FB, RET> f);
 
   /**
    * Logs statement at INFO level.
@@ -197,8 +193,7 @@ public interface LoggerMethods<FB, RET> {
    * @param message the message.
    * @param f the field builder function.
    */
-  void info(
-      @NotNull Condition condition, @Nullable String message, @NotNull Function<FB, RET> f);
+  void info(@NotNull Condition condition, @Nullable String message, @NotNull Function<FB, RET> f);
 
   /**
    * Conditionally logs statement at INFO level with exception.
@@ -256,8 +251,7 @@ public interface LoggerMethods<FB, RET> {
    * @param message the message.
    * @param f the field builder function.
    */
-  void warn(
-      @NotNull Condition condition, @Nullable String message, @NotNull Function<FB, RET> f);
+  void warn(@NotNull Condition condition, @Nullable String message, @NotNull Function<FB, RET> f);
 
   /**
    * Logs statement at INFO level.
@@ -297,8 +291,7 @@ public interface LoggerMethods<FB, RET> {
    * @param message the message.
    * @param f the field builder function.
    */
-  void error(
-      @NotNull Condition condition, @Nullable String message, @NotNull Function<FB, RET> f);
+  void error(@NotNull Condition condition, @Nullable String message, @NotNull Function<FB, RET> f);
 
   /**
    * Conditionally logs statement at INFO level with exception.

--- a/logger/src/test/java/com/tersesystems/echopraxia/MyLogger.java
+++ b/logger/src/test/java/com/tersesystems/echopraxia/MyLogger.java
@@ -3,10 +3,8 @@ package com.tersesystems.echopraxia;
 import com.tersesystems.echopraxia.api.*;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.List;
-
-public class MyLogger extends AbstractLoggerSupport<MyLogger, MyFieldBuilder>
-    implements DefaultLoggerMethods<MyFieldBuilder, List<Field>> {
+public class MyLogger extends AbstractLoggerSupport<MyLogger, MyFieldBuilder, Object>
+    implements DefaultLoggerMethods<MyFieldBuilder, Object> {
 
   public MyLogger(CoreLogger core, MyFieldBuilder fieldBuilder) {
     super(core, fieldBuilder, MyLogger.class);

--- a/logger/src/test/java/com/tersesystems/echopraxia/MyLogger.java
+++ b/logger/src/test/java/com/tersesystems/echopraxia/MyLogger.java
@@ -3,8 +3,10 @@ package com.tersesystems.echopraxia;
 import com.tersesystems.echopraxia.api.*;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.List;
+
 public class MyLogger extends AbstractLoggerSupport<MyLogger, MyFieldBuilder>
-    implements DefaultLoggerMethods<MyFieldBuilder> {
+    implements DefaultLoggerMethods<MyFieldBuilder, List<Field>> {
 
   public MyLogger(CoreLogger core, MyFieldBuilder fieldBuilder) {
     super(core, fieldBuilder, MyLogger.class);

--- a/logstash/src/main/java/com/tersesystems/echopraxia/logstash/LogstashCoreLogger.java
+++ b/logstash/src/main/java/com/tersesystems/echopraxia/logstash/LogstashCoreLogger.java
@@ -199,14 +199,15 @@ public class LogstashCoreLogger implements CoreLogger {
   }
 
   @Override
-  public <FB> void log(
+  public <FB, RET> void log(
       @NotNull Level level,
       String message,
-      @NotNull Function<FB, List<Field>> f,
+      @NotNull Function<FB, RET> f,
       @NotNull FB builder) {
     // When passing a condition through with explicit arguments, we pull the args and make
     // them available through context.
-    final List<Field> args = f.apply(builder);
+    // XXX find the right object for this
+    final List<Field> args = (List<Field>) f.apply(builder);
     final Marker m = context.getMarker();
     final LogstashLoggingContext argContext =
         new LogstashLoggingContext(() -> args, Collections::emptyList);
@@ -227,16 +228,16 @@ public class LogstashCoreLogger implements CoreLogger {
   }
 
   @Override
-  public <FB> void log(
+  public <FB, RET> void log(
       @NotNull Level level,
       @NotNull Condition condition,
       @Nullable String message,
-      @NotNull Function<FB, List<Field>> f,
+      @NotNull Function<FB, RET> f,
       @NotNull FB builder) {
     final Marker m = context.getMarker();
     // When passing a condition through with explicit arguments, we pull the args and make
     // them available through context.
-    final List<Field> args = f.apply(builder);
+    final List<Field> args = (List<Field>) f.apply(builder);
     LogstashLoggingContext argContext =
         new LogstashLoggingContext(() -> args, Collections::emptyList);
     if (logger.isEnabledFor(m, convertLogbackLevel(level))

--- a/logstash/src/test/java/com/tersesystems/echopraxia/logstash/LogstashLoggerTest.java
+++ b/logstash/src/test/java/com/tersesystems/echopraxia/logstash/LogstashLoggerTest.java
@@ -15,7 +15,6 @@ import com.tersesystems.echopraxia.api.Value;
 import com.tersesystems.echopraxia.async.AsyncLogger;
 import java.io.IOException;
 import java.io.StringWriter;
-import java.util.Arrays;
 import java.util.Optional;
 import java.util.UUID;
 import net.logstash.logback.argument.StructuredArgument;
@@ -103,7 +102,7 @@ class LogstashLoggerTest extends TestBase {
   @Test
   void testNullArgument() {
     Logger<?> logger = getLogger();
-    logger.debug("hello {}", fb -> fb.only(fb.nullField("nothing")));
+    logger.debug("hello {}", fb -> fb.nullField("nothing"));
 
     final ListAppender<ILoggingEvent> listAppender = getListAppender();
     final ILoggingEvent event = listAppender.list.get(0);
@@ -162,7 +161,7 @@ class LogstashLoggerTest extends TestBase {
   void testNullArrayElement() {
     Logger<?> logger = getLogger();
     String[] values = {"1", null, "3"};
-    logger.debug("array field is {}", fb -> fb.only(fb.array("arrayName", values)));
+    logger.debug("array field is {}", fb -> fb.array("arrayName", values));
 
     final ListAppender<ILoggingEvent> listAppender = getListAppender();
     final ILoggingEvent event = listAppender.list.get(0);
@@ -173,7 +172,7 @@ class LogstashLoggerTest extends TestBase {
   @Test
   void testNullObject() {
     Logger<?> logger = getLogger();
-    logger.debug("object is {}", fb -> fb.only(fb.object("name", Value.object((Field) null))));
+    logger.debug("object is {}", fb -> (fb.object("name", Value.object((Field) null))));
 
     final ListAppender<ILoggingEvent> listAppender = getListAppender();
     final ILoggingEvent event = listAppender.list.get(0);
@@ -191,8 +190,7 @@ class LogstashLoggerTest extends TestBase {
           Field name = fb.string("name", "will");
           Field age = fb.number("age", 13);
           Field toys = fb.array("toys", "binkie", "dotty");
-          Field person = fb.object("person", name, age, toys);
-          return fb.list(person);
+          return fb.object("person", name, age, toys);
         });
 
     final ListAppender<ILoggingEvent> listAppender = getListAppender();
@@ -220,7 +218,7 @@ class LogstashLoggerTest extends TestBase {
     logger.error(
         "Error {}",
         fb ->
-            Arrays.asList(
+            fb.list(
                 fb.string("operation", "MyOperation"),
                 fb.exception(new IllegalStateException("oh noes"))));
 
@@ -243,7 +241,7 @@ class LogstashLoggerTest extends TestBase {
     Logger<UUIDFieldBuilder> logger = getLogger().withFieldBuilder(new UUIDFieldBuilder() {});
 
     UUID uuid = UUID.randomUUID();
-    logger.error("user id {}", fb -> fb.only(fb.uuid("user_id", uuid)));
+    logger.error("user id {}", fb -> fb.uuid("user_id", uuid));
 
     final ListAppender<ILoggingEvent> listAppender = getListAppender();
     final ILoggingEvent event = listAppender.list.get(0);


### PR DESCRIPTION
Move the return type so that a fieldbuilder function doesn't have `List<Field>` hardcoded, and it can be left up to the logger.