### PR TITLE
Fix thread local context method being lost

### DIFF
--- a/logstash/src/main/java/com/tersesystems/echopraxia/logstash/LogstashCoreLogger.java
+++ b/logstash/src/main/java/com/tersesystems/echopraxia/logstash/LogstashCoreLogger.java
@@ -105,7 +105,7 @@ public class LogstashCoreLogger implements CoreLogger {
     LogstashLoggingContext newContext =
         new LogstashLoggingContext(() -> f.apply(builder), Collections::emptyList);
     return new LogstashCoreLogger(
-        fqcn, logger, this.context.and(newContext), condition, executor, mdcContext());
+        fqcn, logger, this.context.and(newContext), condition, executor, threadContextFunction);
   }
 
   @Override


### PR DESCRIPTION
If `withLocal` was called after `withThreadLocal` then the thread local function would be lost.