### PR TITLE
Optimize logstash withFields method

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -47,6 +47,38 @@ SLF4JLoggerBenchmarks.infoWithException           avgt    5  236.811 ±  0.590  
 SLF4JLoggerBenchmarks.isInfoEnabled               avgt    5    3.407 ±  0.229  ns/op
 ```
 
+Benchmark                                             Mode  Cnt    Score    Error  Units
+LoggerBenchmarks.info                                 avgt    5   56.929 ±  0.950  ns/op
+LoggerBenchmarks.info:·async                          avgt           NaN             ---
+LoggerBenchmarks.infoWithAlways                       avgt    5   54.330 ±  1.807  ns/op
+LoggerBenchmarks.infoWithAlways:·async                avgt           NaN             ---
+LoggerBenchmarks.infoWithContextChain                 avgt    5  238.810 ± 39.113  ns/op
+LoggerBenchmarks.infoWithContextChain:·async          avgt           NaN             ---
+LoggerBenchmarks.infoWithContextString                avgt    5   61.978 ±  0.351  ns/op
+LoggerBenchmarks.infoWithContextString:·async         avgt           NaN             ---
+LoggerBenchmarks.infoWithErrorCondition               avgt    5    4.480 ±  0.506  ns/op
+LoggerBenchmarks.infoWithErrorCondition:·async        avgt           NaN             ---
+LoggerBenchmarks.infoWithException                    avgt    5  294.817 ± 33.051  ns/op
+LoggerBenchmarks.infoWithException:·async             avgt           NaN             ---
+LoggerBenchmarks.infoWithFieldBuilder                 avgt    5   61.851 ±  0.174  ns/op
+LoggerBenchmarks.infoWithFieldBuilder:·async          avgt           NaN             ---
+LoggerBenchmarks.infoWithNever                        avgt    5    0.426 ±  0.009  ns/op
+LoggerBenchmarks.infoWithNever:·async                 avgt           NaN             ---
+LoggerBenchmarks.infoWithParameterizedString          avgt    5  122.649 ± 16.556  ns/op
+LoggerBenchmarks.infoWithParameterizedString:·async   avgt           NaN             ---
+LoggerBenchmarks.infoWithStringArg                    avgt    5  122.520 ± 12.063  ns/op
+LoggerBenchmarks.infoWithStringArg:·async             avgt           NaN             ---
+LoggerBenchmarks.isInfoEnabled                        avgt    5    3.974 ±  0.899  ns/op
+LoggerBenchmarks.isInfoEnabled:·async                 avgt           NaN             ---
+LoggerBenchmarks.trace                                avgt    5    3.425 ±  0.184  ns/op
+LoggerBenchmarks.trace:·async                         avgt           NaN             ---
+LoggerBenchmarks.traceWithContextChain                avgt    5   58.407 ±  8.117  ns/op
+LoggerBenchmarks.traceWithContextChain:·async         avgt           NaN             ---
+LoggerBenchmarks.traceWithParameterizedString         avgt    5    3.477 ±  0.051  ns/op
+LoggerBenchmarks.traceWithParameterizedString:·async  avgt           NaN             ---
+
+
+
 `CoreLoggerBenchmarks` shows the CoreLogger SPI.  
 
 `SLF4JLoggerBenchmarks` show the SLF4J API being called directly for comparison -- what you'd see if you were using straight Logback.

--- a/build.gradle
+++ b/build.gradle
@@ -55,8 +55,8 @@ subprojects { subproj ->
         // easier to use the oracle JDK because it has debug symbols available
         // https://github.com/jvm-profiling-tools/async-profiler#installing-debug-symbols
         // sdk use java 17.0.3-oracle
-        // args = ['-prof', 'async:output=flamegraph;alloc=2m']
-        args = ['-prof', 'async:output=async-profiler.txt;alloc=2m']
+        args = ['-prof', 'async:output=flamegraph']
+        //args = ['-prof', 'async:output=async-profiler.txt;alloc=2m']
     }
 
     // to make sure benchmarks always get compiled

--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,12 @@ subprojects { subproj ->
         // To enable the built-in stacktrace sampling profiler
         //args = ['-prof', 'stack']
         //args = ['-prof', 'gc']
-        //args = ['-prof', 'async:output=flamegraph']
+
+        // easier to use the oracle JDK because it has debug symbols available
+        // https://github.com/jvm-profiling-tools/async-profiler#installing-debug-symbols
+        // sdk use java 17.0.3-oracle
+        // args = ['-prof', 'async:output=flamegraph;alloc=2m']
+        args = ['-prof', 'async:output=async-profiler.txt;alloc=2m']
     }
 
     // to make sure benchmarks always get compiled

--- a/logstash/src/jmh/java/com/tersesystems/echopraxia/logstash/LoggerBenchmarks.java
+++ b/logstash/src/jmh/java/com/tersesystems/echopraxia/logstash/LoggerBenchmarks.java
@@ -78,6 +78,11 @@ public class LoggerBenchmarks {
   }
 
   @Benchmark
+  public void infoWithContextChain() {
+    logger.withFields(fb -> fb.string("foo", "bar")).info("Message");
+  }
+
+  @Benchmark
   public void trace() {
     // should never log
     logger.trace("Trace Message");
@@ -88,4 +93,10 @@ public class LoggerBenchmarks {
     // should never log
     logger.trace("Message {}", fb -> fb.string("foo", "bar"));
   }
+
+  @Benchmark
+  public void traceWithContextChain() {
+    logger.withFields(fb -> fb.string("foo", "bar")).trace("Message");
+  }
+
 }

--- a/logstash/src/jmh/java/com/tersesystems/echopraxia/logstash/LoggerBenchmarks.java
+++ b/logstash/src/jmh/java/com/tersesystems/echopraxia/logstash/LoggerBenchmarks.java
@@ -98,5 +98,4 @@ public class LoggerBenchmarks {
   public void traceWithContextChain() {
     logger.withFields(fb -> fb.string("foo", "bar")).trace("Message");
   }
-
 }

--- a/logstash/src/main/java/com/tersesystems/echopraxia/logstash/LogstashCoreLogger.java
+++ b/logstash/src/main/java/com/tersesystems/echopraxia/logstash/LogstashCoreLogger.java
@@ -141,8 +141,7 @@ public class LogstashCoreLogger implements CoreLogger {
   @Override
   public @NotNull CoreLogger withCondition(@NotNull Condition condition) {
     if (condition == Condition.always()) {
-      // XXX this can't be right, test it
-      return this;
+      return this; // "x && true" is always x
     }
     if (condition == Condition.never()) {
       if (this.condition == Condition.never()) {
@@ -251,7 +250,13 @@ public class LogstashCoreLogger implements CoreLogger {
   @Override
   public <FB> void asyncLog(
       @NotNull Level level, @NotNull Consumer<LoggerHandle<FB>> consumer, @NotNull FB builder) {
-    Marker callerMarker = callerMarker();
+    @Nullable LogstashCallerMarker result;
+    if (isAsyncCallerEnabled()) {
+      result = new LogstashCallerMarker(fqcn, new Throwable());
+    } else {
+      result = null;
+    }
+    Marker callerMarker = result;
     Runnable threadLocalRunnable = threadContextFunction.get();
     runAsyncLog(
         () -> {
@@ -267,7 +272,13 @@ public class LogstashCoreLogger implements CoreLogger {
       @NotNull Condition c,
       @NotNull Consumer<LoggerHandle<FB>> consumer,
       @NotNull FB builder) {
-    Marker callerMarker = callerMarker();
+    @Nullable LogstashCallerMarker result;
+    if (isAsyncCallerEnabled()) {
+      result = new LogstashCallerMarker(fqcn, new Throwable());
+    } else {
+      result = null;
+    }
+    Marker callerMarker = result;
     Runnable threadLocalRunnable = threadContextFunction.get();
     runAsyncLog(
         () -> {
@@ -284,7 +295,13 @@ public class LogstashCoreLogger implements CoreLogger {
       @NotNull Supplier<List<Field>> extraFields,
       @NotNull Consumer<LoggerHandle<FB>> consumer,
       @NotNull FB builder) {
-    final Marker callerMarker = callerMarker();
+    @Nullable LogstashCallerMarker result;
+    if (isAsyncCallerEnabled()) {
+      result = new LogstashCallerMarker(fqcn, new Throwable());
+    } else {
+      result = null;
+    }
+    final Marker callerMarker = result;
     Runnable threadLocalRunnable = threadContextFunction.get();
     runAsyncLog(
         () -> {
@@ -302,7 +319,13 @@ public class LogstashCoreLogger implements CoreLogger {
       @NotNull Condition c,
       @NotNull Consumer<LoggerHandle<FB>> consumer,
       @NotNull FB builder) {
-    final Marker callerMarker = callerMarker();
+    @Nullable LogstashCallerMarker result;
+    if (isAsyncCallerEnabled()) {
+      result = new LogstashCallerMarker(fqcn, new Throwable());
+    } else {
+      result = null;
+    }
+    final Marker callerMarker = result;
     Runnable threadLocalRunnable = threadContextFunction.get();
     runAsyncLog(
         () -> {
@@ -311,15 +334,6 @@ public class LogstashCoreLogger implements CoreLogger {
           final LoggerHandle<FB> loggerHandle = newHandle(level, c, builder, callerLogger);
           consumer.accept(loggerHandle);
         });
-  }
-
-  @Nullable
-  protected LogstashCallerMarker callerMarker() {
-    if (isAsyncCallerEnabled()) {
-      return new LogstashCallerMarker(fqcn, new Throwable());
-    } else {
-      return null;
-    }
   }
 
   /**

--- a/logstash/src/main/java/com/tersesystems/echopraxia/logstash/LogstashCoreLogger.java
+++ b/logstash/src/main/java/com/tersesystems/echopraxia/logstash/LogstashCoreLogger.java
@@ -109,25 +109,19 @@ public class LogstashCoreLogger implements CoreLogger {
   }
 
   public CoreLogger withMarkers(Marker... markers) {
-    LogstashLoggingContext newContext =
-      new LogstashLoggingContext(Collections::emptyList, () -> Arrays.asList(markers));
+    final LogstashLoggingContext contextWithMarkers =
+        this.context.withMarkers(() -> Arrays.asList(markers));
     return new LogstashCoreLogger(
-      fqcn, logger, this.context.and(newContext), condition, executor, threadContextFunction);
-  }
-
-  private List<Field> convertToFields(FieldBuilderResult result) {
-    if (result == null) {
-      // XXX log an error
-      return Collections.emptyList();
-    }
-    return result.fields();
+        fqcn, logger, contextWithMarkers, condition, executor, threadContextFunction);
   }
 
   @Override
   public @NotNull CoreLogger withThreadContext(
       @NotNull Function<Supplier<Map<String, String>>, Supplier<List<Field>>> mapTransform) {
-    LogstashLoggingContext newContext = context.withFields(mapTransform.apply(MDC::getCopyOfContextMap));
-    return new LogstashCoreLogger(fqcn, logger, newContext, condition, executor, threadContextFunction);
+    LogstashLoggingContext newContext =
+        context.withFields(mapTransform.apply(MDC::getCopyOfContextMap));
+    return new LogstashCoreLogger(
+        fqcn, logger, newContext, condition, executor, threadContextFunction);
   }
 
   @Override
@@ -218,7 +212,8 @@ public class LogstashCoreLogger implements CoreLogger {
       final LogstashLoggingContext argContext = context.withFields(() -> args);
       if (condition.test(level, argContext)) {
         final Object[] arguments = convertArguments(args);
-        logger.log(context.resolveFieldsAndMarkers(), fqcn, convertLevel(level), message, arguments, null);
+        logger.log(
+            context.resolveFieldsAndMarkers(), fqcn, convertLevel(level), message, arguments, null);
       }
     }
   }
@@ -247,7 +242,8 @@ public class LogstashCoreLogger implements CoreLogger {
       final LogstashLoggingContext argContext = context.withFields(() -> args);
       if (this.condition.and(condition).test(level, argContext)) {
         final Object[] arguments = convertArguments(args);
-        logger.log(context.resolveFieldsAndMarkers(), fqcn, convertLevel(level), message, arguments, null);
+        logger.log(
+            context.resolveFieldsAndMarkers(), fqcn, convertLevel(level), message, arguments, null);
       }
     }
   }
@@ -498,6 +494,14 @@ public class LogstashCoreLogger implements CoreLogger {
         callerLogger.log(level, c, message, f, builder);
       }
     };
+  }
+
+  private List<Field> convertToFields(FieldBuilderResult result) {
+    if (result == null) {
+      // XXX log an error
+      return Collections.emptyList();
+    }
+    return result.fields();
   }
 
   public String toString() {

--- a/logstash/src/main/java/com/tersesystems/echopraxia/logstash/LogstashLoggingContext.java
+++ b/logstash/src/main/java/com/tersesystems/echopraxia/logstash/LogstashLoggingContext.java
@@ -11,6 +11,7 @@ import java.util.stream.Stream;
 import net.logstash.logback.marker.LogstashMarker;
 import net.logstash.logback.marker.Markers;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Marker;
 
 /**
@@ -111,10 +112,25 @@ public class LogstashLoggingContext extends AbstractLoggingContext {
     };
   }
 
+  @Nullable org.slf4j.Marker resolveMarkers() {
+    List<Marker> markers = getMarkers();
+    // XXX there should be a way to cache this if we know it hasn't changed, since it
+    // could be calculated repeatedly.
+    if (markers.isEmpty()) {
+      return null;
+    } else if (markers.size() == 1) {
+      return markers.get(0);
+    } else {
+      return Markers.aggregate(markers);
+    }
+  }
+
   // Convert markers explicitly.
-  org.slf4j.Marker getMarker() {
+  @Nullable org.slf4j.Marker resolveFieldsAndMarkers() {
     final List<Field> fields = getFields();
     final List<Marker> markers = getMarkers();
+
+    // XXX use resolve markers?
 
     // XXX there should be a way to cache this if we know it hasn't changed, since it
     // could be calculated repeatedly.

--- a/logstash/src/main/java/com/tersesystems/echopraxia/logstash/LogstashLoggingContext.java
+++ b/logstash/src/main/java/com/tersesystems/echopraxia/logstash/LogstashLoggingContext.java
@@ -34,16 +34,18 @@ public class LogstashLoggingContext extends AbstractLoggingContext {
   protected LogstashLoggingContext(Supplier<List<Field>> f, Supplier<List<Marker>> m) {
     this.fieldsSupplier = f;
     this.markersSupplier = m;
-    this.markersResult = Utilities.memoize(() -> {
-      List<Marker> markers = getMarkers();
-      if (markers.isEmpty()) {
-        return null;
-      } else if (markers.size() == 1) {
-        return markers.get(0);
-      } else {
-        return Markers.aggregate(markers);
-      }
-    });
+    this.markersResult =
+        Utilities.memoize(
+            () -> {
+              List<Marker> markers = getMarkers();
+              if (markers.isEmpty()) {
+                return null;
+              } else if (markers.size() == 1) {
+                return markers.get(0);
+              } else {
+                return Markers.aggregate(markers);
+              }
+            });
   }
 
   public static LogstashLoggingContext create(List<Field> fields) {

--- a/logstash/src/test/java/com/tersesystems/echopraxia/logstash/LogstashLoggerTest.java
+++ b/logstash/src/test/java/com/tersesystems/echopraxia/logstash/LogstashLoggerTest.java
@@ -61,7 +61,7 @@ class LogstashLoggerTest extends TestBase {
   }
 
   @Test
-  public void testAsyncLoggerLocation() throws InterruptedException {
+  public void testAsyncLoggerLocation() {
     final EncodingListAppender<ILoggingEvent> stringAppender = getStringAppender();
     AsyncLogger<?> asyncLogger = getAsyncLogger();
     asyncLogger.info("Boring Message");


### PR DESCRIPTION
Can get some speed increases by memoizing the logstash context so that the suppliers only ever evaluate once.

However, this is a problem where the input may change on successive calls, i.e.

```java
Logger<?> loggerWithMillis = logger.withFields(fb -> fb.number("millis", System.currentTimeMillis()));
loggerWithMillis.info("Time render millis);
Thread.sleep(1000L);
loggerWithMillis.info("Should have different millis");
```

will render the same millis even though it should render the current time.