### PR TITLE
Do not memoize a context result

### DIFF
--- a/api/src/main/java/com/tersesystems/echopraxia/api/AbstractLoggingContext.java
+++ b/api/src/main/java/com/tersesystems/echopraxia/api/AbstractLoggingContext.java
@@ -28,7 +28,7 @@ public abstract class AbstractLoggingContext implements LoggingContext {
           .build();
 
   private final Supplier<DocumentContext> supplier =
-      new Utilities.MemoizingSupplier<>(() -> JsonPath.parse(this, configuration));
+      Utilities.memoize(() -> JsonPath.parse(this, configuration));
 
   private @NotNull <T> Optional<T> optionalFind(
       @NotNull String jsonPath, @NotNull Class<T> desiredClass) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group=com.tersesystems.echopraxia
 
-version=2.0.1
+version=2.0.2-SNAPSHOT

--- a/log4j/src/main/java/com/tersesystems/echopraxia/log4j/Log4JLoggingContext.java
+++ b/log4j/src/main/java/com/tersesystems/echopraxia/log4j/Log4JLoggingContext.java
@@ -2,7 +2,6 @@ package com.tersesystems.echopraxia.log4j;
 
 import com.tersesystems.echopraxia.api.AbstractLoggingContext;
 import com.tersesystems.echopraxia.api.Field;
-import com.tersesystems.echopraxia.api.Utilities;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Supplier;

--- a/log4j/src/main/java/com/tersesystems/echopraxia/log4j/Log4JLoggingContext.java
+++ b/log4j/src/main/java/com/tersesystems/echopraxia/log4j/Log4JLoggingContext.java
@@ -21,7 +21,7 @@ public class Log4JLoggingContext extends AbstractLoggingContext {
   }
 
   protected Log4JLoggingContext(Supplier<List<Field>> f, Marker m) {
-    this.fieldsSupplier = Utilities.memoize(f);
+    this.fieldsSupplier = f;
     this.marker = m;
   }
 

--- a/logstash/src/main/java/com/tersesystems/echopraxia/logstash/LogstashLoggingContext.java
+++ b/logstash/src/main/java/com/tersesystems/echopraxia/logstash/LogstashLoggingContext.java
@@ -29,7 +29,7 @@ public class LogstashLoggingContext extends AbstractLoggingContext {
   protected final Supplier<List<Marker>> markersSupplier;
 
   protected LogstashLoggingContext(Supplier<List<Field>> f, Supplier<List<Marker>> m) {
-    this.fieldsSupplier = Utilities.memoize(f);
+    this.fieldsSupplier = f;
     this.markersSupplier = m;
   }
 

--- a/logstash/src/main/java/com/tersesystems/echopraxia/logstash/LogstashLoggingContext.java
+++ b/logstash/src/main/java/com/tersesystems/echopraxia/logstash/LogstashLoggingContext.java
@@ -2,7 +2,6 @@ package com.tersesystems.echopraxia.logstash;
 
 import com.tersesystems.echopraxia.api.AbstractLoggingContext;
 import com.tersesystems.echopraxia.api.Field;
-import com.tersesystems.echopraxia.api.Utilities;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;


### PR DESCRIPTION
Because a context field can contain time dependent (or state dependent) values that can change between calls, it's not appropriate to memoize the context's result -- it is "call by name"

It might be appropriate to pass in memoized fields that are just a straight list, rather than a function -- having a field builder does make it kind of confusing sometimes.

TODO add tests, ensure that log4j and logstash are both covered, document that context fields are call by name.