### PR TITLE
Add snapshot context for logstash

### DIFF
--- a/api/src/main/java/com/tersesystems/echopraxia/api/AbstractLoggerSupport.java
+++ b/api/src/main/java/com/tersesystems/echopraxia/api/AbstractLoggerSupport.java
@@ -41,6 +41,13 @@ public abstract class AbstractLoggerSupport<SELF extends AbstractLoggerSupport<S
     return fieldBuilder;
   }
 
+  /**
+   * Returns a logger with the given condition attached. All statements must satisfy the
+   * condition(s) to be logged.
+   *
+   * @param condition the condition to evaluate
+   * @return a logger with the condition.
+   */
   @NotNull
   public SELF withCondition(@NotNull Condition condition) {
     if (condition == Condition.always()) {
@@ -52,11 +59,24 @@ public abstract class AbstractLoggerSupport<SELF extends AbstractLoggerSupport<S
     }
   }
 
+  /**
+   * Returns a logger that will evaluate the builder function on every statement and make the
+   * computed fields available to conditions. This method has call-by-name semantics.
+   *
+   * @param f the function to evaluate on every statement.
+   * @return a logger with the context fields.
+   */
   @NotNull
   public SELF withFields(@NotNull Function<FB, FieldBuilderResult> f) {
     return newLogger(core().withFields(f, fieldBuilder));
   }
 
+  /**
+   * Returns a logger with fields provided from the given thread context, i.e. SLF4J or Log4J MDC.
+   * This method is implementation specific, and has call-by-name semantics.
+   *
+   * @return a logger with the given thread context fields.
+   */
   @NotNull
   public SELF withThreadContext() {
     return newLogger(core().withThreadContext(Utilities.threadContext()));

--- a/logstash/src/main/java/com/tersesystems/echopraxia/logstash/LogstashCoreLogger.java
+++ b/logstash/src/main/java/com/tersesystems/echopraxia/logstash/LogstashCoreLogger.java
@@ -103,11 +103,11 @@ public class LogstashCoreLogger implements CoreLogger {
 
   @Override
   public <FB> @NotNull CoreLogger withFields(
-    @NotNull Function<FB, FieldBuilderResult> f, @NotNull FB builder) {
+      @NotNull Function<FB, FieldBuilderResult> f, @NotNull FB builder) {
     final LogstashLoggingContext contextWithFields =
-      this.context.withFields(() -> convertToFields(f.apply(builder)));
+        this.context.withFields(() -> convertToFields(f.apply(builder)));
     return new LogstashCoreLogger(
-      fqcn, logger, contextWithFields, condition, executor, threadContextFunction);
+        fqcn, logger, contextWithFields, condition, executor, threadContextFunction);
   }
 
   public CoreLogger withMarkers(Marker... markers) {

--- a/logstash/src/main/java/com/tersesystems/echopraxia/logstash/MarkerLoggingContext.java
+++ b/logstash/src/main/java/com/tersesystems/echopraxia/logstash/MarkerLoggingContext.java
@@ -1,0 +1,11 @@
+package com.tersesystems.echopraxia.logstash;
+
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Marker;
+
+/** A logstash specific interface that returns a context with markers, for use in conditions. */
+public interface MarkerLoggingContext {
+  @NotNull
+  List<Marker> getMarkers();
+}

--- a/logstash/src/main/java/com/tersesystems/echopraxia/logstash/SnapshotLoggingContext.java
+++ b/logstash/src/main/java/com/tersesystems/echopraxia/logstash/SnapshotLoggingContext.java
@@ -1,0 +1,39 @@
+package com.tersesystems.echopraxia.logstash;
+
+import com.tersesystems.echopraxia.api.AbstractLoggingContext;
+import com.tersesystems.echopraxia.api.Field;
+import com.tersesystems.echopraxia.api.Utilities;
+import java.util.List;
+import java.util.function.Supplier;
+import org.jetbrains.annotations.NotNull;
+import org.slf4j.Marker;
+
+class SnapshotLoggingContext extends AbstractLoggingContext implements MarkerLoggingContext {
+
+  private final Supplier<List<Field>> arguments;
+  private final Supplier<List<Field>> fields;
+
+  private final LogstashLoggingContext context;
+
+  public SnapshotLoggingContext(LogstashLoggingContext context, Supplier<List<Field>> arguments) {
+    // Defers and memoizes the arguments and fields for a single logging statement.
+    this.context = context;
+    this.arguments = Utilities.memoize(arguments);
+    this.fields =
+        Utilities.memoize(LogstashLoggingContext.joinFields(context::getFields, this.arguments));
+  }
+
+  @Override
+  public @NotNull List<Field> getFields() {
+    return fields.get();
+  }
+
+  public List<Field> arguments() {
+    return arguments.get();
+  }
+
+  @Override
+  public @NotNull List<Marker> getMarkers() {
+    return context.getMarkers();
+  }
+}


### PR DESCRIPTION
Makes withFields be properly call-by-name while ensuring it doesn't get evaluated more than once inside a logging statement.