### PR TITLE
Enable with handles

### DIFF
--- a/api/src/main/java/com/tersesystems/echopraxia/api/CoreLogger.java
+++ b/api/src/main/java/com/tersesystems/echopraxia/api/CoreLogger.java
@@ -132,8 +132,23 @@ public interface CoreLogger {
    */
   boolean isEnabled(@NotNull Level level, @NotNull Condition condition);
 
+  /**
+   * Is the logger instance enabled for the given level and conditions?
+   *
+   * @param level the level to log at.
+   * @param extraFields extra fields to present to the logger's condition.
+   * @return true if the instance is enabled for the given level, false otherwise.
+   */
   boolean isEnabled(@NotNull Level level, @NotNull Supplier<List<Field>> extraFields);
 
+  /**
+   * Is the logger instance enabled for the given level and conditions?
+   *
+   * @param level the level to log at.
+   * @param condition the explicit condition that must be met.
+   * @param extraFields extra fields to present to the condition.
+   * @return true if the instance is enabled for the given level, false otherwise.
+   */
   boolean isEnabled(
       @NotNull Level level,
       @NotNull Condition condition,
@@ -151,6 +166,7 @@ public interface CoreLogger {
    * Log a message at the given level.
    *
    * @param level the level to log at.
+   * @param extraFields the extra fields to log.
    * @param message the message string to be logged, may be null.
    */
   void log(
@@ -175,6 +191,7 @@ public interface CoreLogger {
    * Log a message at the given level.
    *
    * @param level the level to log at.
+   * @param extraFields the extra fields to log.
    * @param message the message string to be logged
    * @param f the field builder function
    * @param builder the field builder

--- a/api/src/main/java/com/tersesystems/echopraxia/api/CoreLogger.java
+++ b/api/src/main/java/com/tersesystems/echopraxia/api/CoreLogger.java
@@ -132,6 +132,13 @@ public interface CoreLogger {
    */
   boolean isEnabled(@NotNull Level level, @NotNull Condition condition);
 
+  boolean isEnabled(@NotNull Level level, @NotNull Supplier<List<Field>> extraFields);
+
+  boolean isEnabled(
+      @NotNull Level level,
+      @NotNull Condition condition,
+      @NotNull Supplier<List<Field>> extraFields);
+
   /**
    * Log a message at the given level.
    *
@@ -238,6 +245,18 @@ public interface CoreLogger {
       @Nullable String message,
       @NotNull Function<FB, FieldBuilderResult> f,
       @NotNull FB builder);
+
+  /**
+   * Returns a handle to the underlying logger, which will do a straight passthrough without any
+   * enabled or condition checks.
+   *
+   * @param <FB> the field builder type
+   * @param level the logging level
+   * @param builder the field builder.
+   * @return logger handle.
+   */
+  @NotNull
+  <FB> LoggerHandle<FB> logHandle(@NotNull Level level, @NotNull FB builder);
 
   /**
    * Logs a statement asynchronously using an executor.

--- a/api/src/main/java/com/tersesystems/echopraxia/api/FieldBuilder.java
+++ b/api/src/main/java/com/tersesystems/echopraxia/api/FieldBuilder.java
@@ -130,6 +130,7 @@ public interface FieldBuilder {
    * @param name the name of the field.
    * @param value the value of the field.
    * @return a list containing a single field.
+   * @param <N> the type of number
    */
   @NotNull
   default <N extends Number & Comparable<N>> Field number(

--- a/api/src/main/java/com/tersesystems/echopraxia/api/FieldBuilderWithOnly.java
+++ b/api/src/main/java/com/tersesystems/echopraxia/api/FieldBuilderWithOnly.java
@@ -84,6 +84,7 @@ public interface FieldBuilderWithOnly extends FieldBuilder {
    * @param name the name of the field.
    * @param value the value of the field.
    * @return a list containing a single field.
+   * @param <N> the type of number
    */
   @NotNull
   default <N extends Number & Comparable<N>> FieldBuilderResult onlyNumber(

--- a/api/src/test/java/com/tersesystems/echopraxia/fake/FakeCoreLogger.java
+++ b/api/src/test/java/com/tersesystems/echopraxia/fake/FakeCoreLogger.java
@@ -57,6 +57,19 @@ public class FakeCoreLogger implements CoreLogger {
   }
 
   @Override
+  public boolean isEnabled(@NotNull Level level, @NotNull Supplier<List<Field>> extraFields) {
+    return false;
+  }
+
+  @Override
+  public boolean isEnabled(
+      @NotNull Level level,
+      @NotNull Condition condition,
+      @NotNull Supplier<List<Field>> extraFields) {
+    return false;
+  }
+
+  @Override
   public @NotNull Condition condition() {
     return condition;
   }
@@ -157,6 +170,11 @@ public class FakeCoreLogger implements CoreLogger {
           argContext.getLoggerFields(),
           argContext.getArgumentFields());
     }
+  }
+
+  @Override
+  public @NotNull <FB> LoggerHandle<FB> logHandle(@NotNull Level level, @NotNull FB builder) {
+    return null;
   }
 
   private boolean isEnabledFor(Level level) {

--- a/api/src/test/java/com/tersesystems/echopraxia/fake/FakeCoreLogger.java
+++ b/api/src/test/java/com/tersesystems/echopraxia/fake/FakeCoreLogger.java
@@ -128,8 +128,35 @@ public class FakeCoreLogger implements CoreLogger {
   }
 
   @Override
+  public void log(
+      @NotNull Level level, @NotNull Supplier<List<Field>> extraFields, @Nullable String message) {
+    if (isEnabledFor(level) && this.condition.test(level, context)) {
+      List<Field> fields = context.withFields(extraFields).getFields();
+      System.out.printf("" + message + " level %s fields %s\n", level, fields);
+    }
+  }
+
+  @Override
   public <FB> void log(
       @NotNull Level level,
+      @Nullable String message,
+      @NotNull Function<FB, FieldBuilderResult> f,
+      @NotNull FB builder) {
+    List<Field> args = convert(f.apply(builder));
+    if (isEnabledFor(level)) {
+      FakeLoggingContext memo =
+          new FakeLoggingContext(context::getLoggerFields, context::getArgumentFields);
+      if (this.condition.test(level, memo)) {
+        List<Field> fields = context.getFields();
+        System.out.printf("" + message + " level %s fields %s args %s\n", level, fields, args);
+      }
+    }
+  }
+
+  @Override
+  public <FB> void log(
+      @NotNull Level level,
+      @NotNull Supplier<List<Field>> extraFields,
       @Nullable String message,
       @NotNull Function<FB, FieldBuilderResult> f,
       @NotNull FB builder) {
@@ -148,6 +175,18 @@ public class FakeCoreLogger implements CoreLogger {
   public void log(@NotNull Level level, @NotNull Condition condition, @Nullable String message) {
     if (isEnabledFor(level) && this.condition.and(condition).test(level, context)) {
       List<Field> fields = context.getLoggerFields();
+      System.out.printf("" + message + " level %s fields %s\n", level, fields);
+    }
+  }
+
+  @Override
+  public void log(
+      @NotNull Level level,
+      @NotNull Supplier<List<Field>> extraFields,
+      @NotNull Condition condition,
+      @Nullable String message) {
+    if (isEnabledFor(level) && this.condition.and(condition).test(level, context)) {
+      List<Field> fields = context.withFields(extraFields).getLoggerFields();
       System.out.printf("" + message + " level %s fields %s\n", level, fields);
     }
   }
@@ -173,8 +212,47 @@ public class FakeCoreLogger implements CoreLogger {
   }
 
   @Override
+  public <FB> void log(
+      @NotNull Level level,
+      @NotNull Supplier<List<Field>> extraFields,
+      @NotNull Condition condition,
+      @Nullable String message,
+      @NotNull Function<FB, FieldBuilderResult> f,
+      @NotNull FB builder) {
+    if (isEnabledFor(level)) {
+      FakeLoggingContext argContext =
+          new FakeLoggingContext(
+              () -> context.withFields(extraFields).getLoggerFields(),
+              () -> convert(f.apply(builder)));
+      if (this.condition.and(condition).test(level, argContext)) {
+        System.out.printf(
+            "" + message + " level %s fields %s args %s\n",
+            level,
+            argContext.getLoggerFields(),
+            argContext.getArgumentFields());
+      }
+    }
+  }
+
+  @Override
   public @NotNull <FB> LoggerHandle<FB> logHandle(@NotNull Level level, @NotNull FB builder) {
-    return null;
+    return new LoggerHandle<FB>() {
+      @Override
+      public void log(@Nullable String message) {
+        System.out.printf("" + message + " level %s fields %s\n", level, context.getLoggerFields());
+      }
+
+      @Override
+      public void log(@Nullable String message, @NotNull Function<FB, FieldBuilderResult> f) {
+        FakeLoggingContext ctx =
+            new FakeLoggingContext(context::getLoggerFields, () -> convert(f.apply(builder)));
+        System.out.printf(
+            "" + message + " level %s fields %s args %s\n",
+            level,
+            ctx.getLoggerFields(),
+            ctx.getArgumentFields());
+      }
+    };
   }
 
   private boolean isEnabledFor(Level level) {

--- a/api/src/test/java/com/tersesystems/echopraxia/fake/FakeLoggingContext.java
+++ b/api/src/test/java/com/tersesystems/echopraxia/fake/FakeLoggingContext.java
@@ -81,4 +81,10 @@ public class FakeLoggingContext extends AbstractJsonPathFinder implements Loggin
       }
     };
   }
+
+  public LoggingContext withFields(Supplier<List<Field>> extraFields) {
+    Supplier<List<Field>> lfields =
+        joinFields(FakeLoggingContext.this::getLoggerFields, extraFields);
+    return new FakeLoggingContext(lfields, this::getArgumentFields);
+  }
 }

--- a/log4j/src/main/java/com/tersesystems/echopraxia/log4j/Log4JCoreLogger.java
+++ b/log4j/src/main/java/com/tersesystems/echopraxia/log4j/Log4JCoreLogger.java
@@ -167,6 +167,33 @@ public class Log4JCoreLogger implements CoreLogger {
   }
 
   @Override
+  public boolean isEnabled(@NotNull Level level, @NotNull Supplier<List<Field>> extraFields) {
+    final Marker marker = context.getMarker();
+    final org.apache.logging.log4j.Level log4jLevel = convertLevel(level);
+    if (logger.isEnabled(log4jLevel, marker)) {
+      Log4JLoggingContext ctx = new Log4JLoggingContext(context.withFields(extraFields));
+      return condition.test(level, ctx);
+    } else {
+      return false;
+    }
+  }
+
+  @Override
+  public boolean isEnabled(
+      @NotNull Level level,
+      @NotNull Condition condition,
+      @NotNull Supplier<List<Field>> extraFields) {
+    final Marker marker = context.getMarker();
+    final org.apache.logging.log4j.Level log4jLevel = convertLevel(level);
+    if (logger.isEnabled(log4jLevel, marker)) {
+      Log4JLoggingContext ctx = new Log4JLoggingContext(context.withFields(extraFields));
+      return this.condition.and(condition).test(level, ctx);
+    } else {
+      return false;
+    }
+  }
+
+  @Override
   public void log(@NotNull Level level, String message) {
     final Marker marker = context.getMarker();
     final org.apache.logging.log4j.Level log4jLevel = convertLevel(level);
@@ -317,6 +344,12 @@ public class Log4JCoreLogger implements CoreLogger {
         logger.logMessage(fqcn, log4jLevel, marker, message, e);
       }
     }
+  }
+
+  @Override
+  public @NotNull <FB> LoggerHandle<FB> logHandle(@NotNull Level level, @NotNull FB builder) {
+    StackTraceElement location = includeLocation() ? StackLocatorUtil.calcLocation(fqcn) : null;
+    return null; // XXX FIXME
   }
 
   @Override


### PR DESCRIPTION
Trace logging really doesn't map very well to core logger single methods -- we want to check isEnabled, ensure that source info fields are available to conditions, but then not evaluate them if there's no condition and reuse them if they were available.

This results in something that looks like this:

```scala
  @inline
  private def handle[B: ToValue](
      level: JLevel,
      attempt: => B
  )(implicit line: Line, file: File, enc: Enclosing, args: Args): B = {
    val sourceFields = fb.sourceFields
    val extraFields = (() => fb.list(sourceFields.loggerFields).fields()).asJava
    if (core.isEnabled(level, extraFields)) {
      execute(core, level, sourceFields, attempt)
    } else {
      attempt
    }
  }

  @inline
  private def execute[B: ToValue](core: CoreLogger, level: JLevel, sourceFields: fb.SourceFields, attempt: => B): B = {
    val handle = core.logHandle(level, fb)
    handle.log(fb.enteringTemplate, entering(sourceFields))
    val result = Try(attempt)
    result match {
      case Success(ret) =>
        handle.log(fb.exitingTemplate, exiting(sourceFields, ret))
      case Failure(ex) =>
        handle.log(fb.throwingTemplate, throwing(sourceFields, ex))
    }
    result.get // rethrow the exception
  }
```

And... well, if you call `coreLogger.log()` then you evaluate conditions several times (`enter` / `exit`) etc and it's just a mess.

Doing it this way means that evaluation is down to 30 ns per evaluation (between the implicit source info and putting suppliers together) for disabled logger statements, and it limits the upper bound on field re-evaluation when it is enabled.  