### PR TITLE
Filters should run through array and leverage thread

### DIFF
--- a/api/src/main/java/com/tersesystems/echopraxia/api/CoreLoggerFactory.java
+++ b/api/src/main/java/com/tersesystems/echopraxia/api/CoreLoggerFactory.java
@@ -16,7 +16,9 @@ import org.jetbrains.annotations.NotNull;
  */
 public class CoreLoggerFactory {
 
-  private static final Filters filters = new Filters(ClassLoader.getSystemClassLoader());
+  private static final ClassLoader[] classLoaders = {ClassLoader.getSystemClassLoader()};
+
+  private static final Filters filters = new Filters(classLoaders);
 
   @NotNull
   public static CoreLogger getLogger(@NotNull String fqcn, @NotNull Class<?> clazz) {
@@ -50,22 +52,22 @@ public class CoreLoggerFactory {
     static final CoreLoggerProvider INSTANCE = init();
   }
 
-  private static class Filters {
+  public static class Filters {
 
     private final List<CoreLoggerFilter> filterList;
 
     private static final String PROPERTIES_FILE = "echopraxia.properties";
 
-    public Filters(@NotNull ClassLoader classLoader) {
+    public Filters(@NotNull ClassLoader[] classLoaders) {
       InputStream inputStream = CoreLoggerFactory.class.getResourceAsStream("/" + PROPERTIES_FILE);
 
       if (inputStream != null) {
         try {
           Properties props = new Properties();
           props.load(inputStream);
-          filterList = getFilters(props, classLoader);
+          filterList = getFilters(props, classLoaders);
         } catch (IOException e) {
-          throw new ServiceConfigurationError("", e);
+          throw new ServiceConfigurationError(e.getMessage(), e);
         }
       } else {
         filterList = Collections.emptyList();
@@ -74,7 +76,7 @@ public class CoreLoggerFactory {
 
     @NotNull
     private List<CoreLoggerFilter> getFilters(
-        @NotNull Properties props, @NotNull ClassLoader classLoader) {
+        @NotNull Properties props, @NotNull ClassLoader[] classLoaders) {
       List<String> result = new LinkedList<>();
       String value;
       for (int i = 0; (value = props.getProperty("filter." + i)) != null; i++) {
@@ -82,15 +84,47 @@ public class CoreLoggerFactory {
       }
       Stream<String> stream = result.stream();
       return stream
-          .map(className -> this.getFilterInstance(classLoader, className))
+          .map(className -> this.getFilterInstance(classLoaders, className))
           .collect(Collectors.toList());
+    }
+
+    Class<?> loadClass(@NotNull ClassLoader[] classLoaders, @NotNull String className)
+        throws ClassNotFoundException {
+      List<ClassNotFoundException> exceptions = new ArrayList<>();
+      for (int i = 0; i < classLoaders.length; i++) {
+        try {
+          @NotNull ClassLoader classLoader = classLoaders[i];
+          return Class.forName(className, true, classLoader);
+        } catch (ClassNotFoundException e) {
+          exceptions.add(e);
+        }
+      }
+
+      // Look up the context class loader if necessary.
+      final ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
+      if (contextClassLoader != null) {
+        try {
+          return Class.forName(className, true, contextClassLoader);
+        } catch (ClassNotFoundException e) {
+          exceptions.add(e);
+        }
+      }
+      @NotNull
+      String msg =
+          "No class found "
+              + className
+              + " using classLoaders "
+              + Arrays.asList(classLoaders)
+              + ", exceptions = "
+              + exceptions;
+      throw new ClassNotFoundException(msg);
     }
 
     @NotNull
     private CoreLoggerFilter getFilterInstance(
-        @NotNull ClassLoader classLoader, @NotNull String className) {
+        @NotNull ClassLoader[] classLoaders, @NotNull String className) {
       try {
-        Class<?> aClass = classLoader.loadClass(className);
+        Class<?> aClass = loadClass(classLoaders, className);
         if (!CoreLoggerFilter.class.isAssignableFrom(aClass)) {
           String msg = "Class " + className + " does not implement CoreLoggerFilter";
           throw new ServiceConfigurationError(msg);
@@ -99,12 +133,13 @@ public class CoreLoggerFactory {
         Class<CoreLoggerFilter> filterClass = (Class<CoreLoggerFilter>) aClass;
         Constructor<CoreLoggerFilter> declaredConstructor = filterClass.getDeclaredConstructor();
         return declaredConstructor.newInstance();
-      } catch (ClassNotFoundException
-          | NoSuchMethodException
+      } catch (NoSuchMethodException
           | InvocationTargetException
           | InstantiationException
-          | IllegalAccessException e) {
-        throw new ServiceConfigurationError("Cannot create an instance from " + className, e);
+          | IllegalAccessException
+          | ClassNotFoundException e) {
+        throw new ServiceConfigurationError(
+            "Cannot create an instance from " + className + ": " + e.getMessage(), e);
       }
     }
 


### PR DESCRIPTION
Make Filters a public class, allow an array of classloaders to be passed in, finally default to the thread's context class loader.

This is because sbt does some fancy in process class loading and so just relying on the app class loader is insufficient.

https://www.scala-sbt.org/1.x/docs/In-Process-Classloaders.html