### PR TITLE
Remove FieldBuilder as lower bound on Logger<FB>

### DIFF
--- a/jul/src/test/java/com/tersesystems/echopraxia/jul/ExceptionHandlerTests.java
+++ b/jul/src/test/java/com/tersesystems/echopraxia/jul/ExceptionHandlerTests.java
@@ -2,16 +2,14 @@ package com.tersesystems.echopraxia.jul;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.tersesystems.echopraxia.Logger;
 import com.tersesystems.echopraxia.api.Condition;
-import com.tersesystems.echopraxia.async.AsyncLogger;
 import org.junit.jupiter.api.Test;
 
 public class ExceptionHandlerTests extends TestBase {
 
   @Test
   public void testBadArgument() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     Integer number = null;
     logger.debug("this has a null value", fb -> fb.number("nullNumber", number.intValue()));
 
@@ -21,9 +19,9 @@ public class ExceptionHandlerTests extends TestBase {
 
   @Test
   public void testBadWithField() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     Integer number = null;
-    Logger<?> badLogger = logger.withFields(fb -> fb.number("nullNumber", number.intValue()));
+    var badLogger = logger.withFields(fb -> fb.number("nullNumber", number.intValue()));
     badLogger.debug("this has a null value");
 
     Throwable throwable = StaticExceptionHandler.head();
@@ -32,12 +30,12 @@ public class ExceptionHandlerTests extends TestBase {
 
   @Test
   public void testConditionAndBadWithField() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     Integer number = null;
     Condition condition =
         (level, context) -> context.findNumber("$.testing").stream().anyMatch(p -> p.equals(5));
 
-    Logger<?> badLogger = logger.withFields(fb -> fb.number("nullNumber", number.intValue()));
+    var badLogger = logger.withFields(fb -> fb.number("nullNumber", number.intValue()));
     badLogger.debug(condition, "I have a bad logger field and a good condition");
 
     Throwable throwable = StaticExceptionHandler.head();
@@ -46,13 +44,13 @@ public class ExceptionHandlerTests extends TestBase {
 
   @Test
   public void testBadConditionWithCondition() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     Integer number = null;
     Condition badCondition =
         (level, context) ->
             context.findNumber("$.testing").stream().anyMatch(p -> p.equals(number.intValue()));
 
-    Logger<?> badLogger = logger.withCondition(badCondition);
+    var badLogger = logger.withCondition(badCondition);
     badLogger.debug("I am passing in {}", fb -> fb.number("testing", 5));
 
     Throwable throwable = StaticExceptionHandler.head();
@@ -61,7 +59,7 @@ public class ExceptionHandlerTests extends TestBase {
 
   @Test
   public void testBadCondition() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     Integer number = null;
     Condition badCondition = (level, context) -> number.intValue() == 5;
 
@@ -73,7 +71,7 @@ public class ExceptionHandlerTests extends TestBase {
 
   @Test
   public void testBadConditionAndArgument() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     Integer number = null;
     Condition badCondition =
         (level, context) ->
@@ -88,7 +86,7 @@ public class ExceptionHandlerTests extends TestBase {
 
   @Test
   public void testAsyncLog() {
-    AsyncLogger<?> asyncLogger = getAsyncLogger();
+    var asyncLogger = getAsyncLogger();
     Integer number = null;
     asyncLogger.info(
         handle -> {
@@ -102,7 +100,7 @@ public class ExceptionHandlerTests extends TestBase {
 
   @Test
   public void testAsyncLogWithField() {
-    AsyncLogger<?> asyncLogger = getAsyncLogger();
+    var asyncLogger = getAsyncLogger();
     Integer number = null;
     asyncLogger
         .withFields(fb -> fb.number("nullNumber", number.intValue()))

--- a/jul/src/test/java/com/tersesystems/echopraxia/jul/JSONFormatterTest.java
+++ b/jul/src/test/java/com/tersesystems/echopraxia/jul/JSONFormatterTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.tersesystems.echopraxia.Logger;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
@@ -13,7 +12,7 @@ public class JSONFormatterTest extends TestBase {
 
   @Test
   void testDebug() throws JsonProcessingException {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     logger.debug("hello");
 
     List<String> list = EncodedListHandler.ndjson();
@@ -28,7 +27,7 @@ public class JSONFormatterTest extends TestBase {
 
   @Test
   void testInfo() throws JsonProcessingException {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     logger.info("hello");
 
     List<String> list = EncodedListHandler.ndjson();
@@ -43,7 +42,7 @@ public class JSONFormatterTest extends TestBase {
 
   @Test
   void testArguments() throws JsonProcessingException {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     logger.info(
         "hello {0}, you are {1}, citizen status {2}",
         fb -> fb.list(fb.string("name", "will"), fb.number("age", 13), fb.bool("citizen", true)));
@@ -61,7 +60,7 @@ public class JSONFormatterTest extends TestBase {
 
   @Test
   void testException() throws JsonProcessingException {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     Throwable expected = new IllegalStateException("oh noes");
     logger.error("Error", expected);
 

--- a/jul/src/test/java/com/tersesystems/echopraxia/jul/JULLoggerTest.java
+++ b/jul/src/test/java/com/tersesystems/echopraxia/jul/JULLoggerTest.java
@@ -2,7 +2,6 @@ package com.tersesystems.echopraxia.jul;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.tersesystems.echopraxia.Logger;
 import com.tersesystems.echopraxia.api.Field;
 import com.tersesystems.echopraxia.api.FieldBuilder;
 import java.util.List;
@@ -17,7 +16,7 @@ class JULLoggerTest extends TestBase {
 
   @Test
   void testDebug() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     logger.debug("hello");
 
     List<LogRecord> list = EncodedListHandler.records();
@@ -28,7 +27,7 @@ class JULLoggerTest extends TestBase {
 
   @Test
   void testInfo() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     logger.info("hello");
 
     List<LogRecord> list = EncodedListHandler.records();
@@ -39,7 +38,7 @@ class JULLoggerTest extends TestBase {
 
   @Test
   void testArguments() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     logger.info(
         "hello {0}, you are {1}, citizen status {2}",
         fb -> fb.list(fb.string("name", "will"), fb.number("age", 13), fb.bool("citizen", true)));
@@ -56,7 +55,7 @@ class JULLoggerTest extends TestBase {
 
   @Test
   void testWithThreadContext() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     MDC.put("mdckey", "mdcvalue");
     logger.withThreadContext().info("hello");
 
@@ -70,7 +69,7 @@ class JULLoggerTest extends TestBase {
 
   @Test
   void testException() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     Throwable expected = new IllegalStateException("oh noes");
     logger.error("Error", expected);
 

--- a/jul/src/test/java/com/tersesystems/echopraxia/jul/TestBase.java
+++ b/jul/src/test/java/com/tersesystems/echopraxia/jul/TestBase.java
@@ -33,7 +33,7 @@ public class TestBase {
     EncodedListHandler.clear();
   }
 
-  Logger<?> getLogger() {
+  Logger<FieldBuilder> getLogger() {
     return LoggerFactory.getLogger(getCoreLogger(), FieldBuilder.instance());
   }
 

--- a/log4j/src/jmh/java/com/tersesystems/echopraxia/log4j/LoggerBenchmarks.java
+++ b/log4j/src/jmh/java/com/tersesystems/echopraxia/log4j/LoggerBenchmarks.java
@@ -4,6 +4,7 @@ import com.tersesystems.echopraxia.*;
 import com.tersesystems.echopraxia.api.Condition;
 import com.tersesystems.echopraxia.api.FieldBuilder;
 import com.tersesystems.echopraxia.api.Level;
+import com.tersesystems.echopraxia.api.PresentationFieldBuilder;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.infra.Blackhole;
@@ -14,18 +15,19 @@ import org.openjdk.jmh.infra.Blackhole;
 @Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
 @Fork(1)
 public class LoggerBenchmarks {
-  private static final com.tersesystems.echopraxia.Logger<?> logger = LoggerFactory.getLogger();
+  private static final Logger<PresentationFieldBuilder> logger = LoggerFactory.getLogger();
   private static final Exception exception = new RuntimeException();
 
-  private static final com.tersesystems.echopraxia.Logger<?> neverLogger =
+  private static final Logger<PresentationFieldBuilder> neverLogger =
       logger.withCondition(Condition.never());
-  private static final com.tersesystems.echopraxia.Logger<?> alwaysLogger =
+  private static final Logger<PresentationFieldBuilder> alwaysLogger =
       logger.withCondition(Condition.always());
-  private static final com.tersesystems.echopraxia.Logger<?> conditionLogger =
+  private static final Logger<PresentationFieldBuilder> conditionLogger =
       logger.withCondition((level, context) -> level.equals(Level.ERROR));
-  private static final com.tersesystems.echopraxia.Logger<?> fieldBuilderLogger =
+  private static final Logger<?> fieldBuilderLogger =
       logger.withFieldBuilder(FieldBuilder.instance());
-  private static final Logger<?> contextLogger = logger.withFields(fb -> fb.string("foo", "bar"));
+  private static final Logger<PresentationFieldBuilder> contextLogger =
+      logger.withFields(fb -> fb.string("foo", "bar"));
 
   @Benchmark
   public void info() {

--- a/log4j/src/test/java/com/tersesystems/echopraxia/log4j/ConditionTest.java
+++ b/log4j/src/test/java/com/tersesystems/echopraxia/log4j/ConditionTest.java
@@ -7,10 +7,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.tersesystems.echopraxia.Logger;
 import com.tersesystems.echopraxia.api.Condition;
 import com.tersesystems.echopraxia.api.Level;
-import com.tersesystems.echopraxia.async.AsyncLogger;
 import com.tersesystems.echopraxia.log4j.appender.ListAppender;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -23,7 +21,7 @@ public class ConditionTest extends TestBase {
 
   @Test
   void testCondition() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     LongAdder adder = new LongAdder();
     Condition condition =
         (l, c) -> {
@@ -49,8 +47,8 @@ public class ConditionTest extends TestBase {
           return level.equals(Level.INFO);
         };
 
-    Logger<?> logger = getLogger();
-    Logger<?> loggerWithCondition =
+    var logger = getLogger();
+    var loggerWithCondition =
         logger.withCondition(hasInfoLevel).withFields(f -> f.string("herp", "derp"));
 
     LongAdder fieldConditionAdder = new LongAdder();
@@ -71,11 +69,11 @@ public class ConditionTest extends TestBase {
   @Test
   void testFieldConditionIsLive() {
     Condition hasDerp = Condition.valueMatch("herp", f -> f.raw().equals("derp"));
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     final AtomicReference<String> changeableValue = new AtomicReference<>("derp");
 
     // we need to know that withFields is "call by name" and is evaluated fresh on every statement.
-    Logger<?> loggerWithContext = logger.withFields(f -> f.string("herp", changeableValue.get()));
+    var loggerWithContext = logger.withFields(f -> f.string("herp", changeableValue.get()));
 
     loggerWithContext.info(hasDerp, "has derp");
     changeableValue.set("notderp");
@@ -93,12 +91,12 @@ public class ConditionTest extends TestBase {
   @Test
   void testThreadContextConditionIsLive() {
     Condition hasDerp = Condition.valueMatch("herp", f -> f.raw().equals("derp"));
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
 
     ThreadContext.put("herp", "derp");
     // we need to know that withThreadContext is "call by name" and is evaluated fresh on every
     // statement.
-    Logger<?> loggerWithContext = logger.withThreadContext();
+    var loggerWithContext = logger.withThreadContext();
     loggerWithContext.info(hasDerp, "has derp");
 
     ThreadContext.put("herp", "notderp");
@@ -126,7 +124,7 @@ public class ConditionTest extends TestBase {
         };
 
     AtomicBoolean logged = new AtomicBoolean(false);
-    AsyncLogger<?> loggerWithCondition = getAsyncLogger().withCondition(c);
+    var loggerWithCondition = getAsyncLogger().withCondition(c);
     loggerWithCondition.info(
         handle -> {
           handle.log("async logging test");
@@ -155,7 +153,7 @@ public class ConditionTest extends TestBase {
           }
           return true;
         };
-    AsyncLogger<?> loggerWithCondition = getAsyncLogger().withCondition(c);
+    var loggerWithCondition = getAsyncLogger().withCondition(c);
     loggerWithCondition.info(
         handle -> {
           handle.log("async logging test");
@@ -176,7 +174,7 @@ public class ConditionTest extends TestBase {
   @Test
   void testFailedAsyncLogging() {
     AtomicBoolean logged = new AtomicBoolean(false);
-    AsyncLogger<?> loggerWithCondition = getAsyncLogger();
+    var loggerWithCondition = getAsyncLogger();
     loggerWithCondition.info(
         handle -> {
           handle.log(

--- a/log4j/src/test/java/com/tersesystems/echopraxia/log4j/ContextTest.java
+++ b/log4j/src/test/java/com/tersesystems/echopraxia/log4j/ContextTest.java
@@ -28,8 +28,7 @@ public class ContextTest extends TestBase {
     Marker securityMarker = MarkerManager.getMarker("SECURITY");
     Log4JCoreLogger core =
         (Log4JCoreLogger) CoreLoggerFactory.getLogger(Logger.class.getName(), ContextTest.class);
-    Logger<?> logger =
-        LoggerFactory.getLogger(core.withMarker(securityMarker), FieldBuilder.instance());
+    var logger = LoggerFactory.getLogger(core.withMarker(securityMarker), FieldBuilder.instance());
     logger.error("Message {}", fb -> fb.string("field_name", "field_value"));
 
     JsonNode entry = getEntry();
@@ -47,8 +46,7 @@ public class ContextTest extends TestBase {
     final Marker securityMarker = MarkerManager.getMarker("SECURITY");
     Log4JCoreLogger core =
         (Log4JCoreLogger) CoreLoggerFactory.getLogger(Logger.class.getName(), ContextTest.class);
-    Logger<?> logger =
-        LoggerFactory.getLogger(core.withMarker(securityMarker), FieldBuilder.instance());
+    var logger = LoggerFactory.getLogger(core.withMarker(securityMarker), FieldBuilder.instance());
 
     org.apache.logging.log4j.Logger log4jLogger = core.logger();
 
@@ -64,7 +62,7 @@ public class ContextTest extends TestBase {
 
   @Test
   void testComplexFields() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     logger
         .withFields(
             fb -> {
@@ -88,7 +86,7 @@ public class ContextTest extends TestBase {
   @Test
   void testThreadContext() {
     ThreadContext.put("mdckey", "mdcvalue");
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     logger.withThreadContext().error("message with mdc context");
 
     JsonNode entry = getEntry();
@@ -99,7 +97,7 @@ public class ContextTest extends TestBase {
 
   @Test
   void testFindExceptionStackTraceElement() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     Condition c =
         (level, ctx) -> {
           Map<String, ?> element = ctx.findObject("$.exception.stackTrace[0]").get();
@@ -115,7 +113,7 @@ public class ContextTest extends TestBase {
 
   @Test
   void testFindDouble() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     Condition c =
         (level, ctx) -> ctx.findNumber("$.arg1").filter(f -> f.doubleValue() == 1.5).isPresent();
     logger.info(c, "Matches on arg1", fb -> fb.number("arg1", 1.5));

--- a/log4j/src/test/java/com/tersesystems/echopraxia/log4j/ExceptionHandlerTests.java
+++ b/log4j/src/test/java/com/tersesystems/echopraxia/log4j/ExceptionHandlerTests.java
@@ -2,16 +2,14 @@ package com.tersesystems.echopraxia.log4j;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.tersesystems.echopraxia.Logger;
 import com.tersesystems.echopraxia.api.Condition;
-import com.tersesystems.echopraxia.async.AsyncLogger;
 import org.junit.jupiter.api.Test;
 
 public class ExceptionHandlerTests extends TestBase {
 
   @Test
   public void testBadArgument() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     Integer number = null;
     logger.debug("this has a null value", fb -> fb.number("nullNumber", number.intValue()));
 
@@ -21,9 +19,9 @@ public class ExceptionHandlerTests extends TestBase {
 
   @Test
   public void testBadWithField() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     Integer number = null;
-    Logger<?> badLogger = logger.withFields(fb -> fb.number("nullNumber", number.intValue()));
+    var badLogger = logger.withFields(fb -> fb.number("nullNumber", number.intValue()));
     badLogger.debug("this has a null value");
 
     Throwable throwable = StaticExceptionHandler.head();
@@ -32,12 +30,12 @@ public class ExceptionHandlerTests extends TestBase {
 
   @Test
   public void testConditionAndBadWithField() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     Integer number = null;
     Condition condition =
         (level, context) -> context.findNumber("$.testing").stream().anyMatch(p -> p.equals(5));
 
-    Logger<?> badLogger = logger.withFields(fb -> fb.number("nullNumber", number.intValue()));
+    var badLogger = logger.withFields(fb -> fb.number("nullNumber", number.intValue()));
     badLogger.debug(condition, "I have a bad logger field and a good condition");
 
     Throwable throwable = StaticExceptionHandler.head();
@@ -46,13 +44,13 @@ public class ExceptionHandlerTests extends TestBase {
 
   @Test
   public void testBadConditionWithCondition() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     Integer number = null;
     Condition badCondition =
         (level, context) ->
             context.findNumber("$.testing").stream().anyMatch(p -> p.equals(number.intValue()));
 
-    Logger<?> badLogger = logger.withCondition(badCondition);
+    var badLogger = logger.withCondition(badCondition);
     badLogger.debug("I am passing in {}", fb -> fb.number("testing", 5));
 
     Throwable throwable = StaticExceptionHandler.head();
@@ -61,7 +59,7 @@ public class ExceptionHandlerTests extends TestBase {
 
   @Test
   public void testBadCondition() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     Integer number = null;
     Condition badCondition = (level, context) -> number.intValue() == 5;
 
@@ -73,7 +71,7 @@ public class ExceptionHandlerTests extends TestBase {
 
   @Test
   public void testBadConditionAndArgument() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     Integer number = null;
     Condition badCondition =
         (level, context) ->
@@ -88,7 +86,7 @@ public class ExceptionHandlerTests extends TestBase {
 
   @Test
   public void testAsyncLog() {
-    AsyncLogger<?> asyncLogger = getAsyncLogger();
+    var asyncLogger = getAsyncLogger();
     Integer number = null;
     asyncLogger.info(
         handle -> {
@@ -102,7 +100,7 @@ public class ExceptionHandlerTests extends TestBase {
 
   @Test
   public void testAsyncLogWithField() {
-    AsyncLogger<?> asyncLogger = getAsyncLogger();
+    var asyncLogger = getAsyncLogger();
     Integer number = null;
     asyncLogger
         .withFields(fb -> fb.number("nullNumber", number.intValue()))

--- a/log4j/src/test/java/com/tersesystems/echopraxia/log4j/Log4JLoggerTest.java
+++ b/log4j/src/test/java/com/tersesystems/echopraxia/log4j/Log4JLoggerTest.java
@@ -7,7 +7,6 @@ import com.tersesystems.echopraxia.*;
 import com.tersesystems.echopraxia.api.Field;
 import com.tersesystems.echopraxia.api.FieldBuilder;
 import com.tersesystems.echopraxia.api.Value;
-import com.tersesystems.echopraxia.async.AsyncLogger;
 import com.tersesystems.echopraxia.async.AsyncLoggerFactory;
 import org.junit.jupiter.api.Test;
 
@@ -15,7 +14,7 @@ public class Log4JLoggerTest extends TestBase {
 
   @Test
   void testNullMessage() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     logger.debug(null);
 
     JsonNode entry = getEntry();
@@ -25,7 +24,7 @@ public class Log4JLoggerTest extends TestBase {
 
   @Test
   void testNullStringArgument() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     String value = null;
     logger.info("hello {}", fb -> (fb.string("name", value)));
 
@@ -36,7 +35,7 @@ public class Log4JLoggerTest extends TestBase {
 
   @Test
   void testNullFieldName() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     String value = "value";
     logger.debug("array field is {}", fb -> (fb.array(null, value)));
 
@@ -47,7 +46,7 @@ public class Log4JLoggerTest extends TestBase {
 
   @Test
   void testNullNumber() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     Integer value = null;
     logger.debug("number is {}", fb -> (fb.number("name", value)));
 
@@ -58,7 +57,7 @@ public class Log4JLoggerTest extends TestBase {
 
   @Test
   void testNullBoolean() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     logger.debug("boolean is {}", fb -> (fb.bool("name", (Boolean) null)));
 
     JsonNode entry = getEntry();
@@ -68,7 +67,7 @@ public class Log4JLoggerTest extends TestBase {
 
   @Test
   void testNullArrayElement() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     String[] values = {"1", null, "3"};
     logger.debug("array field is {}", fb -> (fb.array("arrayName", values)));
 
@@ -79,7 +78,7 @@ public class Log4JLoggerTest extends TestBase {
 
   @Test
   void testNullObject() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     logger.debug("object is {}", fb -> (fb.object("name", Value.object((Field) null))));
 
     JsonNode entry = getEntry();
@@ -90,7 +89,7 @@ public class Log4JLoggerTest extends TestBase {
 
   @Test
   public void testLoggerWithStringField() {
-    Logger<?> logger = LoggerFactory.getLogger(getClass());
+    var logger = LoggerFactory.getLogger(getClass());
     logger.info("my argument is {}", fb -> fb.string("random_key", "random_value"));
 
     JsonNode entry = getEntry();
@@ -103,7 +102,7 @@ public class Log4JLoggerTest extends TestBase {
 
   @Test
   public void testLoggerLocation() {
-    Logger<?> logger = LoggerFactory.getLogger(getClass());
+    var logger = LoggerFactory.getLogger(getClass());
     logger.info("Boring Message"); // this is line 109
 
     JsonNode entry = getEntry();
@@ -121,7 +120,7 @@ public class Log4JLoggerTest extends TestBase {
   public void testLoggerLocationWithAsyncLogger() {
     // note you must have includeLocation="true" in log4j2.xml to trigger the
     // throwable / stacktrace in the core logger...
-    AsyncLogger<?> asyncLogger = AsyncLoggerFactory.getLogger(getClass(), FieldBuilder.instance());
+    var asyncLogger = AsyncLoggerFactory.getLogger(getClass(), FieldBuilder.instance());
     asyncLogger.info("Boring Message");
 
     waitUntilMessages();
@@ -137,7 +136,7 @@ public class Log4JLoggerTest extends TestBase {
 
   @Test
   public void testLoggerWithObjectField() {
-    Logger<?> logger = LoggerFactory.getLogger(getClass());
+    var logger = LoggerFactory.getLogger(getClass());
     logger.info(
         "my argument is {}",
         fb -> {
@@ -158,7 +157,7 @@ public class Log4JLoggerTest extends TestBase {
 
   @Test
   public void testLoggerWithSeveralObjectField() {
-    Logger<?> logger = LoggerFactory.getLogger(getClass());
+    var logger = LoggerFactory.getLogger(getClass());
     logger.info(
         "my arguments are {} {}",
         fb ->
@@ -190,7 +189,7 @@ public class Log4JLoggerTest extends TestBase {
 
   @Test
   public void testLoggerWithArrayField() {
-    Logger<?> logger = LoggerFactory.getLogger(getClass());
+    var logger = LoggerFactory.getLogger(getClass());
     logger.info(
         "my argument is {}",
         fb -> {
@@ -211,7 +210,7 @@ public class Log4JLoggerTest extends TestBase {
 
   @Test
   public void testLoggerWithThrowable() {
-    Logger<?> logger = LoggerFactory.getLogger(getClass());
+    var logger = LoggerFactory.getLogger(getClass());
     Exception exception = new RuntimeException("Some exception");
     logger.error("Message", exception);
 
@@ -225,7 +224,7 @@ public class Log4JLoggerTest extends TestBase {
 
   @Test
   public void testLoggerWithThrowableField() {
-    Logger<?> logger = LoggerFactory.getLogger(getClass());
+    var logger = LoggerFactory.getLogger(getClass());
     Exception exception = new RuntimeException("Some exception");
     logger.error("Message {}", fb -> fb.exception(exception));
 
@@ -239,7 +238,7 @@ public class Log4JLoggerTest extends TestBase {
 
   @Test
   public void testLoggerWithContextField() {
-    Logger<?> logger =
+    var logger =
         LoggerFactory.getLogger(getClass())
             .withFields(fb -> fb.string("context_name", "context_field"));
     logger.error("Message");
@@ -254,7 +253,7 @@ public class Log4JLoggerTest extends TestBase {
 
   @Test
   public void testLoggerWithContextAndArgumentField() {
-    Logger<?> logger =
+    var logger =
         LoggerFactory.getLogger(getClass())
             .withFields(fb -> fb.string("context_name", "context_field"));
     logger.error("Message {}", fb -> fb.string("arg_name", "arg_field"));

--- a/log4j/src/test/java/com/tersesystems/echopraxia/log4j/TestBase.java
+++ b/log4j/src/test/java/com/tersesystems/echopraxia/log4j/TestBase.java
@@ -7,10 +7,13 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.tersesystems.echopraxia.Logger;
 import com.tersesystems.echopraxia.LoggerFactory;
+import com.tersesystems.echopraxia.api.FieldBuilder;
+import com.tersesystems.echopraxia.api.PresentationFieldBuilder;
 import com.tersesystems.echopraxia.async.AsyncLogger;
 import com.tersesystems.echopraxia.async.AsyncLoggerFactory;
 import com.tersesystems.echopraxia.log4j.appender.ListAppender;
 import java.util.List;
+import org.jetbrains.annotations.NotNull;
 import org.junit.jupiter.api.BeforeEach;
 
 public class TestBase {
@@ -22,11 +25,12 @@ public class TestBase {
     listAppender.clear();
   }
 
-  Logger<?> getLogger() {
+  @NotNull
+  Logger<PresentationFieldBuilder> getLogger() {
     return LoggerFactory.getLogger();
   }
 
-  AsyncLogger<?> getAsyncLogger() {
+  AsyncLogger<FieldBuilder> getAsyncLogger() {
     return AsyncLoggerFactory.getLogger();
   }
 

--- a/logger/src/main/java/com/tersesystems/echopraxia/Logger.java
+++ b/logger/src/main/java/com/tersesystems/echopraxia/Logger.java
@@ -11,7 +11,7 @@ import org.jetbrains.annotations.Nullable;
  *
  * @param <FB> the field builder type.
  */
-public class Logger<FB extends FieldBuilder> extends AbstractLoggerSupport<Logger<FB>, FB>
+public class Logger<FB> extends AbstractLoggerSupport<Logger<FB>, FB>
     implements DefaultLoggerMethods<FB> {
 
   // This is where the logging methods are called, so the stacktrace element shows
@@ -58,7 +58,7 @@ public class Logger<FB extends FieldBuilder> extends AbstractLoggerSupport<Logge
    *
    * @param <FB> the field builder type.
    */
-  public static class NeverLogger<FB extends FieldBuilder> extends Logger<FB> {
+  public static class NeverLogger<FB> extends Logger<FB> {
 
     protected NeverLogger(@NotNull CoreLogger core, @NotNull FB fieldBuilder) {
       super(core, fieldBuilder);

--- a/logstash/src/jmh/java/com/tersesystems/echopraxia/logstash/LoggerBenchmarks.java
+++ b/logstash/src/jmh/java/com/tersesystems/echopraxia/logstash/LoggerBenchmarks.java
@@ -4,6 +4,7 @@ import com.tersesystems.echopraxia.*;
 import com.tersesystems.echopraxia.api.Condition;
 import com.tersesystems.echopraxia.api.FieldBuilder;
 import com.tersesystems.echopraxia.api.Level;
+import com.tersesystems.echopraxia.api.PresentationFieldBuilder;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.*;
 import org.openjdk.jmh.infra.Blackhole;
@@ -14,7 +15,7 @@ import org.openjdk.jmh.infra.Blackhole;
 @Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
 @Fork(1)
 public class LoggerBenchmarks {
-  private static final Logger<?> logger = LoggerFactory.getLogger();
+  private static final Logger<PresentationFieldBuilder> logger = LoggerFactory.getLogger();
   private static final Exception exception = new RuntimeException();
 
   private static final Logger<?> neverLogger = logger.withCondition(Condition.never());

--- a/logstash/src/test/java/com/tersesystems/echopraxia/logstash/ConditionTest.java
+++ b/logstash/src/test/java/com/tersesystems/echopraxia/logstash/ConditionTest.java
@@ -12,7 +12,6 @@ import com.tersesystems.echopraxia.api.Condition;
 import com.tersesystems.echopraxia.api.Field;
 import com.tersesystems.echopraxia.api.Level;
 import com.tersesystems.echopraxia.api.Value;
-import com.tersesystems.echopraxia.async.AsyncLogger;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
@@ -23,7 +22,7 @@ public class ConditionTest extends TestBase {
 
   @Test
   void testCondition() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     Condition condition = (l, c) -> true;
     logger.info(condition, "info");
 
@@ -37,8 +36,8 @@ public class ConditionTest extends TestBase {
   void testConditionWithContext() {
     Condition hasInfoLevel = (level, context) -> level.equals(Level.INFO);
 
-    Logger<?> logger = getLogger();
-    Logger<?> loggerWithCondition =
+    var logger = getLogger();
+    var loggerWithCondition =
         logger.withCondition(hasInfoLevel).withFields(f -> f.string("herp", "derp"));
 
     Condition hasFieldNamedHerp =
@@ -56,7 +55,7 @@ public class ConditionTest extends TestBase {
   @Test
   void testNumberMatch() {
     Condition logins = Condition.numberMatch("logins", v -> v.equals(number(1)));
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     logger.info(logins, "{}", fb -> fb.number("logins", 1));
 
     final ListAppender<ILoggingEvent> listAppender = getListAppender();
@@ -70,7 +69,7 @@ public class ConditionTest extends TestBase {
   @Test
   void testBooleanMatch() {
     Condition logins = Condition.booleanMatch("isAwesome", v -> v.equals(Value.bool(true)));
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     logger.info(logins, "{}", fb -> fb.bool("isAwesome", true));
 
     final ListAppender<ILoggingEvent> listAppender = getListAppender();
@@ -85,7 +84,7 @@ public class ConditionTest extends TestBase {
   void testObjectMatch() {
     Field field = Field.keyValue("foo", Value.string("bar"));
     Condition logins = Condition.objectMatch("myObject", v -> v.equals(Value.object(field)));
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     logger.info(logins, "{}", fb -> fb.object("myObject", List.of(fb.string("foo", "bar"))));
 
     final ListAppender<ILoggingEvent> listAppender = getListAppender();
@@ -99,7 +98,7 @@ public class ConditionTest extends TestBase {
   @Test
   void testArrayMatch() {
     Condition logins = Condition.arrayMatch("myarray", v -> v.equals(Value.array("foo")));
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     logger.info(logins, "{}", fb -> fb.array("myarray", "foo"));
 
     final ListAppender<ILoggingEvent> listAppender = getListAppender();
@@ -113,11 +112,11 @@ public class ConditionTest extends TestBase {
   @Test
   void testFieldConditionIsLive() {
     Condition hasDerp = Condition.stringMatch("herp", v -> Value.equals(v, string("derp")));
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     final AtomicReference<String> changeableValue = new AtomicReference<>("derp");
 
     // we need to know that withFields is "call by name" and is evaluated fresh on every statement.
-    Logger<?> loggerWithContext = logger.withFields(f -> f.string("herp", changeableValue.get()));
+    var loggerWithContext = logger.withFields(f -> f.string("herp", changeableValue.get()));
 
     loggerWithContext.info(hasDerp, "has derp");
     changeableValue.set("notderp");
@@ -134,11 +133,11 @@ public class ConditionTest extends TestBase {
   @Test
   void testMDCConditionIsLive() {
     Condition hasDerp = Condition.stringMatch("herp", v -> Value.equals(v, string("derp")));
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
 
     MDC.put("herp", "derp");
     // we need to know that withFields is "call by name" and is evaluated fresh on every statement.
-    Logger<?> loggerWithContext = logger.withThreadContext();
+    var loggerWithContext = logger.withThreadContext();
 
     loggerWithContext.info(hasDerp, "has derp");
     MDC.put("herp", "notderp");
@@ -165,7 +164,7 @@ public class ConditionTest extends TestBase {
         };
 
     AtomicBoolean logged = new AtomicBoolean(false);
-    AsyncLogger<?> loggerWithCondition = getAsyncLogger().withCondition(c);
+    var loggerWithCondition = getAsyncLogger().withCondition(c);
     loggerWithCondition.info(
         handle -> {
           handle.log("async logging test");
@@ -193,7 +192,7 @@ public class ConditionTest extends TestBase {
           }
           return true;
         };
-    AsyncLogger<?> loggerWithCondition = getAsyncLogger().withCondition(c);
+    var loggerWithCondition = getAsyncLogger().withCondition(c);
     loggerWithCondition.info(
         handle -> {
           handle.log("async logging test");
@@ -211,7 +210,7 @@ public class ConditionTest extends TestBase {
   @Test
   void testFailedAsyncLogging() {
     AtomicBoolean logged = new AtomicBoolean(false);
-    AsyncLogger<?> loggerWithCondition = getAsyncLogger();
+    var loggerWithCondition = getAsyncLogger();
     loggerWithCondition.info(
         handle -> {
           handle.log(

--- a/logstash/src/test/java/com/tersesystems/echopraxia/logstash/ContextTest.java
+++ b/logstash/src/test/java/com/tersesystems/echopraxia/logstash/ContextTest.java
@@ -42,8 +42,7 @@ public class ContextTest extends TestBase {
     final Marker securityMarker = MarkerFactory.getMarker("SECURITY");
     final LogstashCoreLogger core =
         new LogstashCoreLogger(Logger.FQCN, loggerContext.getLogger(getClass().getName()));
-    Logger<?> logger =
-        LoggerFactory.getLogger(core.withMarkers(securityMarker), FieldBuilder.instance());
+    var logger = LoggerFactory.getLogger(core.withMarkers(securityMarker), FieldBuilder.instance());
     logger.withFields(f -> f.string("key", "value")).error("This has a marker");
 
     final ListAppender<ILoggingEvent> listAppender = getListAppender();
@@ -66,7 +65,7 @@ public class ContextTest extends TestBase {
     final LogstashCoreLogger core =
         new LogstashCoreLogger(Logger.FQCN, loggerContext.getLogger(getClass().getName()));
     final CoreLogger security = core.withMarkers(securityMarker);
-    Logger<?> logger = LoggerFactory.getLogger(security, FieldBuilder.instance());
+    var logger = LoggerFactory.getLogger(security, FieldBuilder.instance());
 
     final org.slf4j.Logger slf4jLogger = core.logger();
 
@@ -82,7 +81,7 @@ public class ContextTest extends TestBase {
 
   @Test
   void testComplexFields() throws IOException {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     logger
         .withFields(
             fb -> {
@@ -116,7 +115,7 @@ public class ContextTest extends TestBase {
 
   @Test
   void testArrays() throws IOException {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     logger
         .withFields(
             fb -> {
@@ -149,8 +148,8 @@ public class ContextTest extends TestBase {
 
   @Test
   void testCombinedContext() {
-    Logger<?> logger = getLogger();
-    Logger<?> loggerWithContext = logger.withFields(f -> f.string("key", "value"));
+    var logger = getLogger();
+    var loggerWithContext = logger.withFields(f -> f.string("key", "value"));
     loggerWithContext
         .withFields(f -> f.string("key2", "value2"))
         .info("This should have two contexts.");
@@ -171,7 +170,7 @@ public class ContextTest extends TestBase {
   @Test
   void testThreadContext() {
     MDC.put("mdckey", "mdcvalue");
-    Logger<?> logger = getLogger().withThreadContext();
+    var logger = getLogger().withThreadContext();
     logger.info("some message");
 
     final ListAppender<ILoggingEvent> listAppender = getListAppender();
@@ -185,7 +184,7 @@ public class ContextTest extends TestBase {
 
   @Test
   void testFindString() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     Condition c =
         (level, ctx) -> ctx.findString("$.arg1").filter(v -> v.equals("value1")).isPresent();
     logger.info(c, "Matches on arg1", fb -> fb.string("arg1", "value1"));
@@ -198,7 +197,7 @@ public class ContextTest extends TestBase {
 
   @Test
   void testFindInteger() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     Condition c =
         (level, ctx) -> ctx.findNumber("$.arg1").filter(v -> v.intValue() == 1).isPresent();
     logger.info(c, "Matches on arg1", fb -> fb.number("arg1", 1));
@@ -211,7 +210,7 @@ public class ContextTest extends TestBase {
 
   @Test
   void testFindBoolean() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     Condition c = (level, ctx) -> ctx.findBoolean("$.arg1").orElse(false);
     logger.info(c, "Matches on arg1", fb -> fb.bool("arg1", true));
 
@@ -223,7 +222,7 @@ public class ContextTest extends TestBase {
 
   @Test
   void testFindDouble() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     Condition c =
         (level, ctx) -> ctx.findNumber("$.arg1").filter(f -> f.doubleValue() == 1.5).isPresent();
     logger.info(c, "Matches on arg1", fb -> fb.number("arg1", 1.5));
@@ -236,7 +235,7 @@ public class ContextTest extends TestBase {
 
   @Test
   void testInlinePredicate() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     final Condition cheapBookCondition =
         (level, context) -> !context.findList("$.store.book[?(@.price < 10)]").isEmpty();
 
@@ -258,7 +257,7 @@ public class ContextTest extends TestBase {
 
   @Test
   void testFindNull() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     final Condition nullCondition = (level, context) -> context.findNull("$.myNullField");
 
     logger.info(nullCondition, "found null", fb -> fb.nullField("myNullField"));
@@ -271,7 +270,7 @@ public class ContextTest extends TestBase {
 
   @Test
   void testFindNullButString() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     final Condition nullCondition = (level, context) -> context.findNull("$.myNullField");
 
     logger.info(nullCondition, "found null", fb -> fb.string("myNullField", "notnull"));
@@ -282,7 +281,7 @@ public class ContextTest extends TestBase {
 
   @Test
   void testJsonPathMissingProperty() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     final Condition noFindException =
         (level, ctx) -> ctx.findString("$.exception.message").isPresent();
 
@@ -294,7 +293,7 @@ public class ContextTest extends TestBase {
 
   @Test
   void testMismatchedString() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     final Condition noFindException = (level, ctx) -> ctx.findString("$.notastring").isPresent();
 
     // property is present but is boolean, not a string
@@ -306,7 +305,7 @@ public class ContextTest extends TestBase {
 
   @Test
   void testMismatchedObject() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     final Condition noFindException = (level, ctx) -> ctx.findObject("$.notanobject").isPresent();
 
     // property is present but is boolean, not a string
@@ -318,7 +317,7 @@ public class ContextTest extends TestBase {
 
   @Test
   void testListOfElement() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     final Condition nestedCondition = (level, ctx) -> !ctx.findList("$..notalist").isEmpty();
 
     // property is present, but we need to return a list containing the single element.
@@ -332,7 +331,7 @@ public class ContextTest extends TestBase {
 
   @Test
   void testElementAsSingletonList() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     final Condition findBooleanAsList =
         (level, ctx) -> {
           final Optional<?> first = ctx.findList("$.boolean").stream().findFirst();
@@ -350,7 +349,7 @@ public class ContextTest extends TestBase {
 
   @Test
   void testOptionalEmptyForNothingFound() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     final Condition noFindException =
         (level, ctx) -> {
           final Optional<?> first = ctx.findList("$.exception").stream().findFirst();
@@ -368,7 +367,7 @@ public class ContextTest extends TestBase {
 
   @Test
   void testFindException() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     Condition c =
         (level, ctx) ->
             ctx.findThrowable("$.exception")
@@ -385,7 +384,7 @@ public class ContextTest extends TestBase {
 
   @Test
   void testFindExceptionStacktrace() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     Condition c =
         (level, ctx) -> {
           List<?> trace = ctx.findList("$.exception.stackTrace");
@@ -402,7 +401,7 @@ public class ContextTest extends TestBase {
 
   @Test
   void testFindExceptionStackTraceElement() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     Condition c =
         (level, ctx) -> {
           Map<String, ?> element = ctx.findObject("$.exception.stackTrace[0]").get();
@@ -419,7 +418,7 @@ public class ContextTest extends TestBase {
 
   @Test
   void testNullMessageInException() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     Condition c = (level, ctx) -> ctx.findNull("$.exception.message");
     RuntimeException e = new IllegalArgumentException((String) null);
     logger.info(c, "Matches on null message in exception", e);
@@ -432,7 +431,7 @@ public class ContextTest extends TestBase {
 
   @Test
   void testNullInNestedArray() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     Condition c = (level, ctx) -> !ctx.findList("$..interests").isEmpty();
     logger.info(
         c,
@@ -447,7 +446,7 @@ public class ContextTest extends TestBase {
 
   @Test
   void testObjectArrayObject() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     Condition c = (level, ctx) -> ctx.findBoolean("$.foo.array[2].one").get();
     logger.info(
         c,

--- a/logstash/src/test/java/com/tersesystems/echopraxia/logstash/ConverterTest.java
+++ b/logstash/src/test/java/com/tersesystems/echopraxia/logstash/ConverterTest.java
@@ -1,7 +1,6 @@
 package com.tersesystems.echopraxia.logstash;
 
 import ch.qos.logback.classic.LoggerContext;
-import com.tersesystems.echopraxia.Logger;
 import com.tersesystems.echopraxia.LoggerFactory;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
@@ -32,7 +31,7 @@ public class ConverterTest {
 
   @Test
   public void testLog() {
-    Logger<?> logger = LoggerFactory.getLogger(getClass());
+    var logger = LoggerFactory.getLogger(getClass());
     logger.info("Only arguments", fb -> fb.string("book", "The Cask"));
     logger.withFields(fb -> fb.string("book", "The Cask")).info("Only logger context");
     logger

--- a/logstash/src/test/java/com/tersesystems/echopraxia/logstash/ExceptionHandlerTests.java
+++ b/logstash/src/test/java/com/tersesystems/echopraxia/logstash/ExceptionHandlerTests.java
@@ -4,16 +4,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
-import com.tersesystems.echopraxia.Logger;
 import com.tersesystems.echopraxia.api.Condition;
-import com.tersesystems.echopraxia.async.AsyncLogger;
 import org.junit.jupiter.api.Test;
 
 public class ExceptionHandlerTests extends TestBase {
 
   @Test
   public void testBadArgument() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     Integer number = null;
     logger.debug("this has a null value", fb -> fb.number("nullNumber", number.intValue()));
     final ListAppender<ILoggingEvent> listAppender = getListAppender();
@@ -25,9 +23,9 @@ public class ExceptionHandlerTests extends TestBase {
 
   @Test
   public void testBadWithField() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     Integer number = null;
-    Logger<?> badLogger = logger.withFields(fb -> fb.number("nullNumber", number.intValue()));
+    var badLogger = logger.withFields(fb -> fb.number("nullNumber", number.intValue()));
     badLogger.debug("this has a null value");
     final ListAppender<ILoggingEvent> listAppender = getListAppender();
     assertThat(listAppender.list).isEmpty();
@@ -38,12 +36,12 @@ public class ExceptionHandlerTests extends TestBase {
 
   @Test
   public void testConditionAndBadWithField() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     Integer number = null;
     Condition condition =
         (level, context) -> context.findNumber("$.testing").stream().anyMatch(p -> p.equals(5));
 
-    Logger<?> badLogger = logger.withFields(fb -> fb.number("nullNumber", number.intValue()));
+    var badLogger = logger.withFields(fb -> fb.number("nullNumber", number.intValue()));
     badLogger.debug(condition, "I have a bad logger field and a good condition");
     final ListAppender<ILoggingEvent> listAppender = getListAppender();
     assertThat(listAppender.list).isEmpty();
@@ -54,13 +52,13 @@ public class ExceptionHandlerTests extends TestBase {
 
   @Test
   public void testBadConditionWithCondition() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     Integer number = null;
     Condition badCondition =
         (level, context) ->
             context.findNumber("$.testing").stream().anyMatch(p -> p.equals(number.intValue()));
 
-    Logger<?> badLogger = logger.withCondition(badCondition);
+    var badLogger = logger.withCondition(badCondition);
     badLogger.debug("I am passing in {}", fb -> fb.number("testing", 5));
     final ListAppender<ILoggingEvent> listAppender = getListAppender();
     assertThat(listAppender.list).isEmpty();
@@ -71,7 +69,7 @@ public class ExceptionHandlerTests extends TestBase {
 
   @Test
   public void testBadCondition() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     Integer number = null;
     Condition badCondition = (level, context) -> number.intValue() == 5;
 
@@ -85,7 +83,7 @@ public class ExceptionHandlerTests extends TestBase {
 
   @Test
   public void testBadConditionAndArgument() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     Integer number = null;
     Condition badCondition =
         (level, context) ->
@@ -102,7 +100,7 @@ public class ExceptionHandlerTests extends TestBase {
 
   @Test
   public void testAsyncLog() {
-    AsyncLogger<?> asyncLogger = getAsyncLogger();
+    var asyncLogger = getAsyncLogger();
     Integer number = null;
     asyncLogger.info(
         handle -> {
@@ -116,7 +114,7 @@ public class ExceptionHandlerTests extends TestBase {
 
   @Test
   public void testAsyncLogWithField() {
-    AsyncLogger<?> asyncLogger = getAsyncLogger();
+    var asyncLogger = getAsyncLogger();
     Integer number = null;
     asyncLogger
         .withFields(fb -> fb.number("nullNumber", number.intValue()))

--- a/logstash/src/test/java/com/tersesystems/echopraxia/logstash/LogstashLoggerTest.java
+++ b/logstash/src/test/java/com/tersesystems/echopraxia/logstash/LogstashLoggerTest.java
@@ -12,7 +12,6 @@ import com.tersesystems.echopraxia.*;
 import com.tersesystems.echopraxia.api.Field;
 import com.tersesystems.echopraxia.api.FieldBuilder;
 import com.tersesystems.echopraxia.api.Value;
-import com.tersesystems.echopraxia.async.AsyncLogger;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.Optional;
@@ -27,7 +26,7 @@ class LogstashLoggerTest extends TestBase {
 
   @Test
   void testDebug() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     logger.debug("hello");
 
     final ListAppender<ILoggingEvent> listAppender = getListAppender();
@@ -38,7 +37,7 @@ class LogstashLoggerTest extends TestBase {
 
   @Test
   void testNullMessage() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     logger.debug(null);
 
     final ListAppender<ILoggingEvent> listAppender = getListAppender();
@@ -49,7 +48,7 @@ class LogstashLoggerTest extends TestBase {
 
   @Test
   public void testLoggerLocation() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     logger.info("Boring Message");
 
     // We can't go through the list appender here because it doesn't call the encoder,
@@ -63,7 +62,7 @@ class LogstashLoggerTest extends TestBase {
   @Test
   public void testAsyncLoggerLocation() {
     final EncodingListAppender<ILoggingEvent> stringAppender = getStringAppender();
-    AsyncLogger<?> asyncLogger = getAsyncLogger();
+    var asyncLogger = getAsyncLogger();
     asyncLogger.info("Boring Message");
 
     waitUntilMessages();
@@ -77,7 +76,7 @@ class LogstashLoggerTest extends TestBase {
 
   @Test
   void testArguments() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     logger.debug(
         "hello {}, you are {}, {}",
         fb -> fb.list(fb.string("name", "PERSON"), fb.number("age", 13), fb.bool("citizen", true)));
@@ -90,7 +89,7 @@ class LogstashLoggerTest extends TestBase {
 
   @Test
   void testArrayOfStringsArgument() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     logger.debug("hello {}", fb -> fb.array("toys", "binkie"));
 
     final ListAppender<ILoggingEvent> listAppender = getListAppender();
@@ -101,7 +100,7 @@ class LogstashLoggerTest extends TestBase {
 
   @Test
   void testNullArgument() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     logger.debug("hello {}", fb -> fb.nullField("nothing"));
 
     final ListAppender<ILoggingEvent> listAppender = getListAppender();
@@ -112,7 +111,7 @@ class LogstashLoggerTest extends TestBase {
 
   @Test
   void testNullStringArgument() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     String value = null;
     logger.debug("hello {}", fb -> (fb.string("name", value)));
 
@@ -124,7 +123,7 @@ class LogstashLoggerTest extends TestBase {
 
   @Test
   void testNullFieldName() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     String value = "value";
     logger.debug("hello {}", fb -> (fb.string(null, value)));
 
@@ -136,7 +135,7 @@ class LogstashLoggerTest extends TestBase {
 
   @Test
   void testNullNumber() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     Integer value = null;
     logger.debug("hello {}", fb -> (fb.number("name", value)));
 
@@ -148,7 +147,7 @@ class LogstashLoggerTest extends TestBase {
 
   @Test
   void testNullBoolean() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     logger.debug("boolean is {}", fb -> (fb.bool("name", (Boolean) null)));
 
     final ListAppender<ILoggingEvent> listAppender = getListAppender();
@@ -159,7 +158,7 @@ class LogstashLoggerTest extends TestBase {
 
   @Test
   void testNullArrayElement() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     String[] values = {"1", null, "3"};
     logger.debug("array field is {}", fb -> fb.array("arrayName", values));
 
@@ -171,7 +170,7 @@ class LogstashLoggerTest extends TestBase {
 
   @Test
   void testNullObject() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     logger.debug("object is {}", fb -> (fb.object("name", Value.object((Field) null))));
 
     final ListAppender<ILoggingEvent> listAppender = getListAppender();
@@ -183,7 +182,7 @@ class LogstashLoggerTest extends TestBase {
 
   @Test
   void testObjectArgument() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     logger.debug(
         "hello {}",
         fb -> {
@@ -202,7 +201,7 @@ class LogstashLoggerTest extends TestBase {
 
   @Test
   void testException() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     logger.error("Error", new IllegalStateException("oh noes"));
 
     final ListAppender<ILoggingEvent> listAppender = getListAppender();
@@ -215,7 +214,7 @@ class LogstashLoggerTest extends TestBase {
 
   @Test
   void testArgumentsException() {
-    Logger<?> logger = getLogger();
+    var logger = getLogger();
     logger.error(
         "Error {}",
         fb ->

--- a/logstash/src/test/java/com/tersesystems/echopraxia/logstash/TestBase.java
+++ b/logstash/src/test/java/com/tersesystems/echopraxia/logstash/TestBase.java
@@ -47,7 +47,7 @@ public class TestBase {
     return new LogstashCoreLogger(Logger.FQCN, loggerContext().getLogger(getClass().getName()));
   }
 
-  Logger<?> getLogger() {
+  Logger<FieldBuilder> getLogger() {
     return LoggerFactory.getLogger(getCoreLogger(), FieldBuilder.instance());
   }
 

--- a/scripting/src/test/java/com/tersesystems/echopraxia/scripting/ScriptConditionTest.java
+++ b/scripting/src/test/java/com/tersesystems/echopraxia/scripting/ScriptConditionTest.java
@@ -7,7 +7,6 @@ import static org.slf4j.Logger.ROOT_LOGGER_NAME;
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
-import com.tersesystems.echopraxia.Logger;
 import com.tersesystems.echopraxia.LoggerFactory;
 import com.tersesystems.echopraxia.api.Condition;
 import com.tersesystems.echopraxia.api.Field;
@@ -37,7 +36,7 @@ public class ScriptConditionTest {
                 + "    ctx[\"find_string\"](\"correlation_id\") == \"match\";"
                 + "}",
             Throwable::printStackTrace);
-    Logger<?> logger = LoggerFactory.getLogger(getClass()).withCondition(condition);
+    var logger = LoggerFactory.getLogger(getClass()).withCondition(condition);
     logger.info("data of interest found", fb -> (fb.string("correlation_id", "match")));
 
     ListAppender<ILoggingEvent> listAppender = getListAppender();
@@ -56,7 +55,7 @@ public class ScriptConditionTest {
                 + "    ctx[\"find_number\"](\"correlation_id\") == 123;"
                 + "}",
             Throwable::printStackTrace);
-    Logger<?> logger = LoggerFactory.getLogger(getClass()).withCondition(condition);
+    var logger = LoggerFactory.getLogger(getClass()).withCondition(condition);
     logger.info("data of interest found", fb -> fb.number("correlation_id", 123));
 
     ListAppender<ILoggingEvent> listAppender = getListAppender();
@@ -87,7 +86,7 @@ public class ScriptConditionTest {
                 + "    time.unix_timestamp(now()) > 0;"
                 + "}",
             Throwable::printStackTrace);
-    Logger<?> logger = LoggerFactory.getLogger(getClass()).withCondition(condition);
+    var logger = LoggerFactory.getLogger(getClass()).withCondition(condition);
     logger.info("time is good");
 
     ListAppender<ILoggingEvent> listAppender = getListAppender();
@@ -127,7 +126,7 @@ public class ScriptConditionTest {
                 + "    logger_property(\"herp\") == \"derp\";"
                 + "}",
             Throwable::printStackTrace);
-    Logger<?> logger = LoggerFactory.getLogger(getClass()).withCondition(condition);
+    var logger = LoggerFactory.getLogger(getClass()).withCondition(condition);
     logger.info("the logger property is derp!");
 
     ListAppender<ILoggingEvent> listAppender = getListAppender();
@@ -146,7 +145,7 @@ public class ScriptConditionTest {
                 + "    ctx[\"find_boolean\"](\"bool_value\") == true;"
                 + "}",
             Throwable::printStackTrace);
-    Logger<?> logger = LoggerFactory.getLogger(getClass()).withCondition(condition);
+    var logger = LoggerFactory.getLogger(getClass()).withCondition(condition);
     logger.info("data of interest found", fb -> fb.bool("bool_value", true));
 
     ListAppender<ILoggingEvent> listAppender = getListAppender();
@@ -165,7 +164,7 @@ public class ScriptConditionTest {
                 + "    ctx[:find_null](\"null_value\") == true;"
                 + "}",
             Throwable::printStackTrace);
-    Logger<?> logger = LoggerFactory.getLogger(getClass()).withCondition(condition);
+    var logger = LoggerFactory.getLogger(getClass()).withCondition(condition);
     logger.info("data of interest found", fb -> fb.nullField("null_value"));
 
     ListAppender<ILoggingEvent> listAppender = getListAppender();
@@ -188,7 +187,7 @@ public class ScriptConditionTest {
                 + "    obj[:foo] == 1337;"
                 + "}",
             Throwable::printStackTrace);
-    Logger<?> logger = LoggerFactory.getLogger(getClass()).withCondition(condition);
+    var logger = LoggerFactory.getLogger(getClass()).withCondition(condition);
     logger.info(
         "data of interest found",
         fb -> fb.object("obj", fb.number("foo", 1337), fb.number("bar", 0xDEADBEEF)));
@@ -213,7 +212,7 @@ public class ScriptConditionTest {
                 + "    interests[1] == \"drink\";"
                 + "}",
             Throwable::printStackTrace);
-    Logger<?> logger = LoggerFactory.getLogger(getClass()).withCondition(condition);
+    var logger = LoggerFactory.getLogger(getClass()).withCondition(condition);
     logger.info(
         "data of interest found",
         fb -> fb.object("obj", (fb.array("interests", "food", "drink", "sleep"))));
@@ -237,7 +236,7 @@ public class ScriptConditionTest {
                 + "    fields[:obj][:interests][2] == \"sleep\";"
                 + "}",
             Throwable::printStackTrace);
-    Logger<?> logger = LoggerFactory.getLogger(getClass()).withCondition(condition);
+    var logger = LoggerFactory.getLogger(getClass()).withCondition(condition);
     logger.info(
         "data of interest found",
         fb -> fb.object("obj", (fb.array("interests", "food", "drink", "sleep"))));
@@ -253,7 +252,7 @@ public class ScriptConditionTest {
     Path path = Paths.get("src/test/tweakflow/exception.tf");
     Condition condition = ScriptCondition.create(false, path, Throwable::printStackTrace);
 
-    Logger<?> logger = LoggerFactory.getLogger(getClass()).withCondition(condition);
+    var logger = LoggerFactory.getLogger(getClass()).withCondition(condition);
     logger
         .withFields(fb -> (fb.exception(new RuntimeException("testing"))))
         .info("data of interest found");
@@ -269,7 +268,7 @@ public class ScriptConditionTest {
     Path path = Paths.get("src/test/tweakflow/condition.tf");
     Condition condition = ScriptCondition.create(false, path, Throwable::printStackTrace);
 
-    Logger<?> logger = LoggerFactory.getLogger(getClass()).withCondition(condition);
+    var logger = LoggerFactory.getLogger(getClass()).withCondition(condition);
     logger.withFields(fb -> (fb.string("correlation_id", "match"))).info("data of interest found");
 
     ListAppender<ILoggingEvent> listAppender = getListAppender();
@@ -283,7 +282,7 @@ public class ScriptConditionTest {
     Path path = Paths.get("src/test/tweakflow/condition.tf");
     Condition condition = ScriptCondition.create(false, path, Throwable::printStackTrace);
 
-    Logger<?> logger = LoggerFactory.getLogger(getClass()).withCondition(condition);
+    var logger = LoggerFactory.getLogger(getClass()).withCondition(condition);
     logger.info("this should not log");
 
     ListAppender<ILoggingEvent> listAppender = getListAppender();
@@ -306,7 +305,7 @@ public class ScriptConditionTest {
 
     Condition condition = ScriptCondition.create(false, path, Throwable::printStackTrace);
 
-    Logger<?> logger = LoggerFactory.getLogger(getClass()).withCondition(condition);
+    var logger = LoggerFactory.getLogger(getClass()).withCondition(condition);
     logger
         .withFields(
             fb -> {


### PR DESCRIPTION
JDK 11 lets people write local loggers using`var`, and if defined in a `Logging` interface then the super long `Logger<MyFieldBuilder>` is not exposed to user.  As such, there isn't really a good reason to use `Logger<?>` in 2023, and we can remove the lower bound that requires `Logger<FB extends FieldBuilder>`, meaning that you can provide your own builder context that is completely different.