### PR TITLE
Deprecate attributes

### DIFF
--- a/api/src/main/java/com/tersesystems/echopraxia/spi/DefaultField.java
+++ b/api/src/main/java/com/tersesystems/echopraxia/spi/DefaultField.java
@@ -34,7 +34,9 @@ public class DefaultField implements PresentationField {
   @Override
   public @NotNull DefaultField abbreviateAfter(int after) {
     // Set these on the value so the behavior is consistent
-    Value<?> newValue = value.withAttributes(value.attributes().plus(PresentationHintAttributes.abbreviateAfter(after)));
+    Value<?> newValue =
+        value.withAttributes(
+            value.attributes().plus(PresentationHintAttributes.abbreviateAfter(after)));
     return new DefaultField(name, newValue, attributes);
   }
 
@@ -42,7 +44,8 @@ public class DefaultField implements PresentationField {
   @Override
   public @NotNull DefaultField asCardinal() {
     // Set these on the value so the behavior is consistent
-    Value<?> newValue = value.withAttributes(value.attributes().plus(PresentationHintAttributes.asCardinal()));
+    Value<?> newValue =
+        value.withAttributes(value.attributes().plus(PresentationHintAttributes.asCardinal()));
     return new DefaultField(name, newValue, attributes);
   }
 

--- a/api/src/main/java/com/tersesystems/echopraxia/spi/DefaultField.java
+++ b/api/src/main/java/com/tersesystems/echopraxia/spi/DefaultField.java
@@ -30,14 +30,20 @@ public class DefaultField implements PresentationField {
     return this.withAttribute(PresentationHintAttributes.asValueOnly());
   }
 
+  @Deprecated
   @Override
   public @NotNull DefaultField abbreviateAfter(int after) {
-    return this.withAttribute(PresentationHintAttributes.abbreviateAfter(after));
+    // Set these on the value so the behavior is consistent
+    Value<?> newValue = value.withAttributes(value.attributes().plus(PresentationHintAttributes.abbreviateAfter(after)));
+    return new DefaultField(name, newValue, attributes);
   }
 
+  @Deprecated
   @Override
   public @NotNull DefaultField asCardinal() {
-    return this.withAttribute(PresentationHintAttributes.asCardinal());
+    // Set these on the value so the behavior is consistent
+    Value<?> newValue = value.withAttributes(value.attributes().plus(PresentationHintAttributes.asCardinal()));
+    return new DefaultField(name, newValue, attributes);
   }
 
   @Override

--- a/api/src/main/java/com/tersesystems/echopraxia/spi/PresentationHints.java
+++ b/api/src/main/java/com/tersesystems/echopraxia/spi/PresentationHints.java
@@ -24,7 +24,8 @@ public interface PresentationHints<F extends Field> {
    * Tells the formatter that the array value should be represented as a cardinal number in text.
    *
    * @return field with cardinal attribute set
-   * @deprecated asCardinal attribute only applies to values, this will not set an attribute on the field.
+   * @deprecated asCardinal attribute only applies to values, this will not set an attribute on the
+   *     field.
    */
   @Deprecated
   @NotNull
@@ -34,8 +35,8 @@ public interface PresentationHints<F extends Field> {
    * Tells the formatter that the string value or array value should be abbreviated after the given
    * number of elements.
    *
-   * @deprecated abbreviateAfter attribute only applies to values, this will not set an attribute on the field.
-   *
+   * @deprecated abbreviateAfter attribute only applies to values, this will not set an attribute on
+   *     the field.
    * @param after the maximum number of elements to render
    * @return the field with the attribute applied
    */

--- a/api/src/main/java/com/tersesystems/echopraxia/spi/PresentationHints.java
+++ b/api/src/main/java/com/tersesystems/echopraxia/spi/PresentationHints.java
@@ -21,22 +21,27 @@ public interface PresentationHints<F extends Field> {
   F asValueOnly();
 
   /**
+   * Tells the formatter that the array value should be represented as a cardinal number in text.
+   *
+   * @return field with cardinal attribute set
+   * @deprecated asCardinal attribute only applies to values, this will not set an attribute on the field.
+   */
+  @Deprecated
+  @NotNull
+  F asCardinal();
+
+  /**
    * Tells the formatter that the string value or array value should be abbreviated after the given
    * number of elements.
+   *
+   * @deprecated abbreviateAfter attribute only applies to values, this will not set an attribute on the field.
    *
    * @param after the maximum number of elements to render
    * @return the field with the attribute applied
    */
+  @Deprecated
   @NotNull
   F abbreviateAfter(int after);
-
-  /**
-   * Tells the formatter that the array value should be represented as a cardinal number in text.
-   *
-   * @return field with cardinal attribute set
-   */
-  @NotNull
-  F asCardinal();
 
   /**
    * Tells the formatter that this field should be elided in text.


### PR DESCRIPTION
Deprecate the `abbreviateAfter` and `asCardinal` presentation hints as they really go on the value.