### PR TITLE
Fix dead link docs/usage/conditions.md

### DIFF
--- a/docs/usage/conditions.md
+++ b/docs/usage/conditions.md
@@ -139,7 +139,7 @@ class FindException {
 }
 ```
 
-There are many more options available using JSONPath.  You can try out the [online evaluator](https://jsonpath.herokuapp.com/) to test out expressions.
+There are many more options available using JSONPath.  You can try out the [online evaluator](https://jsoning.com/jsonpath/) to test out expressions.
 
 ## Logger
 


### PR DESCRIPTION
Replace dead link https://jsonpath.herokuapp.com/ with another resource https://jsoning.com/jsonpath/