### PR TITLE
DONOTMERGE Upgrade API dependencies

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -4,6 +4,9 @@ plugins {
 }
 
 dependencies {
+    // json-path depends on SLF4J API so it must be declared here
+    api("org.slf4j:slf4j-api:$slf4jApiVersion")
+
     // https://mvnrepository.com/artifact/com.jayway.jsonpath/json-path
     implementation "com.jayway.jsonpath:json-path:$jsonPathVersion"
     // https://mvnrepository.com/artifact/org.pcollections/pcollections

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -6,5 +6,6 @@ plugins {
 dependencies {
     // https://mvnrepository.com/artifact/com.jayway.jsonpath/json-path
     implementation "com.jayway.jsonpath:json-path:$jsonPathVersion"
-    implementation 'org.pcollections:pcollections:4.0.1'
+    // https://mvnrepository.com/artifact/org.pcollections/pcollections
+    implementation "org.pcollections:pcollections:$pcollectionsVersion"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -77,7 +77,7 @@ subprojects { subproj ->
 
     compileJava {
         // Make sure we can release JDK 1.8 code
-        options.release = 8
+        options.release = 11
     }
 
     dependencies {

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,19 +8,19 @@ org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAME
   --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
   --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
 
-logbackVersion=1.3.8
-logstashVersion=7.4
-tweakflowVersion=1.4.3
+logbackVersion=1.5.12
+logstashVersion=8.0
+tweakflowVersion=1.4.4
 
-log4j2Version=2.20.0
+log4j2Version=2.24.2
 
 jsonPathVersion=2.9.0
 pcollectionsVersion=4.0.2
 
-slf4jApiVersion=2.0.7
-slf4jJdk14Version=2.0.7
+slf4jApiVersion=2.0.16
+slf4jJdk14Version=2.0.16
 
 directoryWatcherVersion=0.18.0
-jacksonDatabindVersion=2.13.3
+jacksonDatabindVersion=2.18.2
 
-zjsonPatchVersion=0.4.14
+zjsonPatchVersion=0.4.16

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,8 @@ tweakflowVersion=1.4.3
 
 log4j2Version=2.20.0
 
-jsonPathVersion=2.8.0
+jsonPathVersion=2.9.0
+pcollectionsVersion=4.0.2
 
 slf4jApiVersion=2.0.7
 slf4jJdk14Version=2.0.7

--- a/logback/build.gradle
+++ b/logback/build.gradle
@@ -7,10 +7,8 @@ dependencies {
 
     // We don't depend on SLF4J 2.x or Logback 1.3 features, but we don't want to bind
     // consumers to them either.
-    compileOnly "org.slf4j:slf4j-api:$slf4jApiVersion"
-    compileOnly "ch.qos.logback:logback-classic:$logbackVersion"
+    implementation "org.slf4j:slf4j-api:$slf4jApiVersion"
+    implementation "ch.qos.logback:logback-classic:$logbackVersion"
 
     testImplementation(testFixtures(project(':api')))
-    testImplementation "org.slf4j:slf4j-api:1.7.36"
-    testImplementation "ch.qos.logback:logback-classic:1.2.12"
 }

--- a/logstash/build.gradle
+++ b/logstash/build.gradle
@@ -17,8 +17,8 @@ dependencies {
     compileOnly "ch.qos.logback:logback-classic:$logbackVersion"
     compileOnly "net.logstash.logback:logstash-logback-encoder:$logstashVersion"
 
-    testImplementation "ch.qos.logback:logback-classic:1.2.12"
+    testImplementation "ch.qos.logback:logback-classic:$logbackVersion"
     // In 7.4, MdcJsonProvider uses getCopyOfContextMap() and mdcAdapter is null.
     // We need a way to set the MDC adapter for Logback 1.2, 1.3, and 1.4 while having it be API compatible.
-    testImplementation "net.logstash.logback:logstash-logback-encoder:7.3"
+    testImplementation "net.logstash.logback:logstash-logback-encoder:$logstashVersion"
 }

--- a/logstash/src/test/java/com/tersesystems/echopraxia/logstash/DirectTest.java
+++ b/logstash/src/test/java/com/tersesystems/echopraxia/logstash/DirectTest.java
@@ -21,6 +21,7 @@ import java.util.Iterator;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.slf4j.helpers.BasicMDCAdapter;
 
 public class DirectTest {
 
@@ -188,6 +189,11 @@ public class DirectTest {
   public void before() {
     try {
       LoggerContext factory = new LoggerContext();
+      factory.setMDCAdapter(new BasicMDCAdapter());
+
+      // If we don't set MDC explicitly here then we get...
+      //at java.lang.NullPointerException: Cannot invoke "org.slf4j.spi.MDCAdapter.getCopyOfContextMap()" because "mdcAdapter" is null
+      //at 	at ch.qos.logback.classic.spi.LoggingEvent.getMDCPropertyMap(LoggingEvent.java:460)
       JoranConfigurator joran = new JoranConfigurator();
       joran.setContext(factory);
       factory.reset();


### PR DESCRIPTION
JSONPath 2.9.0 is incompatible with JSONPath 2.8.0, and has a dependency on SLF4J API 2.0.x

I think that this is unsustainable, as SLF4J forces the API all the way down the line, and JSON path is not strictly speaking required for Echopraxia to work.